### PR TITLE
Update setup-venv.js

### DIFF
--- a/scripts/setup-venv.js
+++ b/scripts/setup-venv.js
@@ -20,7 +20,7 @@ function hasUv() {
 }
 
 // Python executable names to try
-const pythonCommands = ['python3', 'python'];
+const pythonCommands = ['python3', 'python', 'py'];
 
 function findPython() {
   for (const cmd of pythonCommands) {


### PR DESCRIPTION
Added 'py' as a recognized Python command to support newer Python installations that use py as the default launcher alongside 'python3' and 'python'.