### PR TITLE
Add MSeeP.ai badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![MSeeP.ai Security Assessment Badge](https://mseep.net/pr/opactorai-claudable-badge.png)](https://mseep.ai/app/opactorai-claudable)
+
 # Claudable
 
 <img src="./assets/Claudable_main.png" alt="CLovable" style="border-radius: 12px; width: 100%;" />

--- a/apps/api/app/services/cli/unified_manager.py
+++ b/apps/api/app/services/cli/unified_manager.py
@@ -18,7 +18,8 @@ import base64
 def get_project_root() -> str:
     """Get project root directory using relative path navigation"""
     current_file_dir = os.path.dirname(os.path.abspath(__file__))
-    # unified_manager.py -> cli -> services -> app -> api -> apps -> project-root
+    # unified_manager.py is in: app/services/cli/
+    # Navigate: cli -> services -> app -> api -> apps -> project-root
     project_root = os.path.join(current_file_dir, "..", "..", "..", "..", "..")
     return os.path.abspath(project_root)
 
@@ -1026,8 +1027,9 @@ class CursorAgentCLI(BaseCLI):
         try:
             # Read system prompt from the source file using relative path
             current_file_dir = os.path.dirname(os.path.abspath(__file__))
-            # unified_manager.py -> cli -> services -> app
-            app_dir = os.path.join(current_file_dir, "..", "..", "..")
+            # unified_manager.py is in: app/services/cli/
+            # Navigate: cli -> services -> app
+            app_dir = os.path.join(current_file_dir, "..", "..")
             app_dir = os.path.abspath(app_dir)
             system_prompt_path = os.path.join(app_dir, "prompt", "system-prompt.md")
             


### PR DESCRIPTION
Hi there,

This pull request shares a security update on Claudable.

We also have an entry for Claudable in our directory, MSeeP.ai, where we provide regular security and trust updates on your app.

We invite you to add our badge for your MCP server to your README to help your users learn from a third party that provides ongoing validation of Claudable.

You can easily take control over your listing for free: visit it at https://mseep.ai/app/opactorai-claudable.

Yours Sincerely,

Lawrence W. Sinclair
CEO/SkyDeck AI
Founder of MSeeP.ai
*MCP servers you can trust*

---

[![MSeeP.ai Security Assessment Badge](https://mseep.net/pr/opactorai-claudable-badge.png)](https://mseep.ai/app/opactorai-claudable)


Here are our latest evaluation results of Claudable

## Security Scan Results

**Security Score:** 83/100

**Risk Level:** moderate

**Scan Date:** 2025-08-23


Score starts at 100, deducts points for security issues, and adds points for security best practices


### Detected Vulnerabilities


#### High Severity

* **next**
  - [{'source': 1099638, 'name': 'next', 'dependency': 'next', 'title': 'Next.js Cache Poisoning', 'url': 'https://github.com/advisories/GHSA-gp8f-8m3g-qvj9', 'severity': 'high', 'cwe': ['CWE-349', 'CWE-639'], 'cvss': {'score': 7.5, 'vectorString': 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H'}, 'range': '>=14.0.0 <14.2.10'}, {'source': 1100421, 'name': 'next', 'dependency': 'next', 'title': 'Denial of Service condition in Next.js image optimization', 'url': 'https://github.com/advisories/GHSA-g77x-44xx-532m', 'severity': 'moderate', 'cwe': ['CWE-674'], 'cvss': {'score': 5.9, 'vectorString': 'CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H'}, 'range': '>=10.0.0 <14.2.7'}, {'source': 1101380, 'name': 'next', 'dependency': 'next', 'title': 'Next.js authorization bypass vulnerability', 'url': 'https://github.com/advisories/GHSA-7gfc-8cq8-jh5f', 'severity': 'high', 'cwe': ['CWE-285'], 'cvss': {'score': 7.5, 'vectorString': 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N'}, 'range': '>=9.5.5 <14.2.15'}, {'source': 1101438, 'name': 'next', 'dependency': 'next', 'title': 'Next.js Allows a Denial of Service (DoS) with Server Actions', 'url': 'https://github.com/advisories/GHSA-7m27-7ghc-44w9', 'severity': 'moderate', 'cwe': ['CWE-770'], 'cvss': {'score': 5.3, 'vectorString': 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L'}, 'range': '>=14.0.0 <14.2.21'}, {'source': 1104490, 'name': 'next', 'dependency': 'next', 'title': 'Next.js Race Condition to Cache Poisoning', 'url': 'https://github.com/advisories/GHSA-qpjv-v59x-3qc4', 'severity': 'low', 'cwe': ['CWE-362'], 'cvss': {'score': 3.7, 'vectorString': 'CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N'}, 'range': '<14.2.24'}, {'source': 1105461, 'name': 'next', 'dependency': 'next', 'title': 'Information exposure in Next.js dev server due to lack of origin verification', 'url': 'https://github.com/advisories/GHSA-3h52-269p-cp9r', 'severity': 'low', 'cwe': ['CWE-1385'], 'cvss': {'score': 0, 'vectorString': None}, 'range': '>=13.0 <14.2.30'}, {'source': 1106692, 'name': 'next', 'dependency': 'next', 'title': 'Authorization Bypass in Next.js Middleware', 'url': 'https://github.com/advisories/GHSA-f82v-jwr5-mffw', 'severity': 'critical', 'cwe': ['CWE-285'], 'cvss': {'score': 9.1, 'vectorString': 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N'}, 'range': '>=14.0.0 <14.2.25'}]
  - Fixed in version: unknown


#### Medium Severity

* **prismjs**
  - [{'source': 1105770, 'name': 'prismjs', 'dependency': 'prismjs', 'title': 'PrismJS DOM Clobbering vulnerability', 'url': 'https://github.com/advisories/GHSA-x7hr-w5r2-h6wg', 'severity': 'moderate', 'cwe': ['CWE-79', 'CWE-94'], 'cvss': {'score': 4.9, 'vectorString': 'CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:L/I:L/A:N'}, 'range': '<1.30.0'}]
  - Fixed in version: unknown

* **react-syntax-highlighter**
  - ['refractor']
  - Fixed in version: unknown

* **refractor**
  - ['prismjs']
  - Fixed in version: unknown


### Security Findings


#### Low Severity Issues

* **semgrep**: Use of base64 decoding detected. This might indicate obfuscated code.


This security assessment was conducted by MSeeP.ai, an independent security validation service for MCP servers. Visit our [website](https://mseep.ai) to learn more about our security reviews.

