### PR TITLE
model is now changable mid prompt

### DIFF
--- a/apps/api/app/api/chat/act.py
+++ b/apps/api/app/api/chat/act.py
@@ -50,6 +50,47 @@ class ActResponse(BaseModel):
     message: str
 
 
+def build_conversation_context(
+    project_id: str,
+    conversation_id: str | None,
+    db: Session,
+    *,
+    exclude_message_id: str | None = None,
+    limit: int = 20
+) -> str:
+    """Return a formatted snippet of recent chat history for context transfer."""
+
+    query = db.query(Message).filter(Message.project_id == project_id)
+    if conversation_id:
+        query = query.filter(Message.conversation_id == conversation_id)
+
+    history: list[Message] = []
+    for msg in query.order_by(Message.created_at.desc()):
+        if exclude_message_id and msg.id == exclude_message_id:
+            continue
+        if msg.metadata_json and msg.metadata_json.get("hidden_from_ui"):
+            continue
+        if msg.role not in ("user", "assistant"):
+            continue
+        history.append(msg)
+        if len(history) >= limit:
+            break
+
+    if not history:
+        return ""
+
+    history.reverse()
+    lines = []
+    for msg in history:
+        role = "User" if msg.role == "user" else "Assistant"
+        content = (msg.content or "").strip()
+        if not content:
+            continue
+        lines.append(f"{role}:\n{content}")
+
+    return "\n".join(lines)
+
+
 async def execute_act_instruction(
     project_id: str,
     instruction: str,
@@ -116,7 +157,9 @@ async def execute_chat_task(
     db: Session,
     cli_preference: CLIType = None,
     fallback_enabled: bool = True,
-    is_initial_prompt: bool = False
+    is_initial_prompt: bool = False,
+    _request_id: str | None = None,
+    user_message_id: str | None = None
 ):
     """Background task for executing Chat instructions"""
     try:
@@ -162,8 +205,26 @@ async def execute_chat_task(
         # Qwen Coder does not support images yet; drop them to prevent errors
         safe_images = [] if cli_preference == CLIType.QWEN else images
 
+        instruction_payload = instruction
+        if not is_initial_prompt:
+            context_block = build_conversation_context(
+                project_id,
+                conversation_id,
+                db,
+                exclude_message_id=user_message_id
+            )
+            if context_block:
+                instruction_payload = (
+                    "You are continuing an ongoing coding session. Reference the recent conversation history below before acting.\n"
+                    "<conversation_history>\n"
+                    f"{context_block}\n"
+                    "</conversation_history>\n\n"
+                    "Latest user instruction: \n"
+                    f"{instruction}"
+                )
+
         result = await cli_manager.execute_instruction(
-            instruction=instruction,
+            instruction=instruction_payload,
             cli_type=cli_preference,
             fallback_enabled=project_fallback_enabled,
             images=safe_images,
@@ -271,7 +332,8 @@ async def execute_act_task(
     cli_preference: CLIType = None,
     fallback_enabled: bool = True,
     is_initial_prompt: bool = False,
-    request_id: str = None
+    request_id: str = None,
+    user_message_id: str | None = None
 ):
     """Background task for executing Act instructions"""
     try:
@@ -327,8 +389,26 @@ async def execute_act_task(
         # Qwen Coder does not support images yet; drop them to prevent errors
         safe_images = [] if cli_preference == CLIType.QWEN else images
 
+        instruction_payload = instruction
+        if not is_initial_prompt:
+            context_block = build_conversation_context(
+                project_id,
+                conversation_id,
+                db,
+                exclude_message_id=user_message_id
+            )
+            if context_block:
+                instruction_payload = (
+                    "You are continuing an ongoing coding session. Reference the recent conversation history below before acting.\n"
+                    "<conversation_history>\n"
+                    f"{context_block}\n"
+                    "</conversation_history>\n\n"
+                    "Latest user instruction: \n"
+                    f"{instruction}"
+                )
+
         result = await cli_manager.execute_instruction(
-            instruction=instruction,
+            instruction=instruction_payload,
             cli_type=cli_preference,
             fallback_enabled=project_fallback_enabled,
             images=safe_images,
@@ -676,7 +756,8 @@ async def run_act(
         cli_preference,
         fallback_enabled,
         body.is_initial_prompt,
-        request_id
+        request_id,
+        user_message.id
     )
     return ActResponse(
         session_id=session.id,
@@ -817,7 +898,9 @@ async def run_chat(
         db,
         cli_preference,
         fallback_enabled,
-        body.is_initial_prompt
+        body.is_initial_prompt,
+        None,
+        user_message.id
     )
     
     return ActResponse(


### PR DESCRIPTION
apps/api/app/api/chat/act.py – Added a reusable build_conversation_context helper (20 message window, user + assistant) and now both Act and Chat executions embed the recap plus keep Qwen auth/session failures from silently hanging the run. We also pass the originating user_message_id so the context excludes the just-posted entry and the act_complete broadcast always fires, clearing the UI’s busy state.
apps/web/app/[project_id]/chat/page.tsx – Inlined CLI metadata (labels, fallback models) and rebuilt model handling: CLI/model dropdowns are authoritative, we keep a durable conversationId, push both preferences to the API, and reuse the new context block when switching models. If the model list returned by the CLI status endpoint is noisy, we now filter it against our fallbacks so each CLI only exposes its own models. Switching CLIs triggers a default model for that CLI, but preserves established conversation history.
apps/web/components/chat/ChatInput.tsx – Replaced the side-by-side button selector with a vertical assistant/model picker + full-width textarea. The editor receives focus after any dropdown change, accepts input even while a run is in progress (only the send button is disabled), and continues supporting drag/drop/paste image uploads. The UI now mirrors the project-creation flow and prevents the textbox from “disappearing” once a job starts.