### PR TITLE
fix: Codex CLI exec json

### DIFF
--- a/apps/web/app/[project_id]/chat/page.tsx
+++ b/apps/web/app/[project_id]/chat/page.tsx
@@ -39,6 +39,7 @@ const CLI_ORDER = ['claude', 'cursor', 'codex', 'qwen', 'gemini'] as const;
 const MODEL_FALLBACKS: Record<string, { id: string; name: string; aliases?: string[] }[]> = {
   claude: [
     { id: 'claude-sonnet-4', name: 'Claude Sonnet 4', aliases: ['claude-sonnet-4-20250514', 'sonnet-4'] },
+    { id: 'claude-sonnet-4.5', name: 'Claude Sonnet 4.5', aliases: ['claude-sonnet-4-5-20250929', 'sonnet-4.5'] },
     { id: 'claude-opus-4.1', name: 'Claude Opus 4.1', aliases: ['claude-opus-4-1-20250805', 'opus-4.1'] },
     { id: 'claude-opus-4', name: 'Claude Opus 4', aliases: ['claude-opus-4-20250514', 'opus-4'] },
     { id: 'claude-haiku-3.5', name: 'Claude Haiku 3.5', aliases: ['claude-3-5-haiku-20241022', 'haiku-3.5'] }


### PR DESCRIPTION
  - switch the adapter from the deprecated codex … proto entrypoint to codex exec
    --json …, passing through existing configuration overrides
  - normalize Codex event payloads to support both legacy msg wrapper and new
    event / top-level fields, and treat thread.started / turn.started as the
    handshake
  - send the initial instruction via stdin (per exec contract) and support image
    attachments by passing --image arguments
  - handle Codex 0.47’s item.* streaming: surface agent_message items as chat
    replies, summarize command execution start/end, and persist tool metadata
  - tighten error handling/logging and clean up temporary files created for inline
    images

  testing

  - python3 -m py_compile apps/api/app/services/cli/adapters/codex_cli.py
  - manual smoke test: ran codex exec --json … and verified replies now appear in
    the UI

