### PR TITLE
fix: add missing main field for Electron entry point

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+// Main entry point for Electron application
+// This file provides compatibility for tools that expect index.js by default
+// The actual Electron main process is located in electron/main.js
+
+module.exports = require('./electron/main.js');

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "description": "AI-Powered Web App Builder - Build apps with natural language using Claude Code, Cursor, and more",
   "private": true,
+  "main": "index.js",
   "scripts": {
     "dev": "node scripts/run-web.js",
     "dev:web": "node scripts/run-web.js",


### PR DESCRIPTION
Fix Electron configuration by creating root-level index.js file and updating package.json main field to point to index.js. This resolves compatibility issues where tools expect index.js as the default entry point while maintaining the existing Electron main process functionality.