### PR TITLE
fix: update Claude SDK and model configurations

### DIFF
--- a/lib/constants/claudeModels.ts
+++ b/lib/constants/claudeModels.ts
@@ -1,5 +1,5 @@
 export type ClaudeModelId =
-  | 'claude-opus-4-1-20250805'
+  | 'claude-opus-4-5-20251101'
   | 'claude-sonnet-4-5-20250929'
   | 'claude-haiku-4-5-20251001';
 
@@ -17,19 +17,19 @@ export interface ClaudeModelDefinition {
 
 export const CLAUDE_MODEL_DEFINITIONS: ClaudeModelDefinition[] = [
   {
-    id: 'claude-opus-4-1-20250805',
-    name: 'Claude Opus 4.1',
+    id: 'claude-opus-4-5-20251101',
+    name: 'Claude Opus 4.5',
     description: 'Newest Opus release with the strongest reasoning skills',
     supportsImages: true,
     aliases: [
-      'claude-opus-4-1-20250805',
-      'claude-opus-4-1',
-      'claude-opus-4.1',
+      'claude-opus-4-5-20251101',
+      'claude-opus-4-5',
+      'claude-opus-4.5',
       'claude-opus-4',
       'claude-opus',
-      'opus-4-1-20250805',
-      'opus-4-1',
-      'opus-4.1',
+      'opus-4-5-20251101',
+      'opus-4-5',
+      'opus-4.5',
       'opus-4',
       'opus',
       'claude-3-opus',

--- a/lib/services/cli/claude.ts
+++ b/lib/services/cli/claude.ts
@@ -718,7 +718,7 @@ export async function executeClaude(
     const response = query({
       prompt: instruction,
       options: {
-        cwd: absoluteProjectPath, // Work only in project folder (protects Claudable root)
+        workingDirectory: absoluteProjectPath, // Work only in project folder (protects Claudable root)
         additionalDirectories: [absoluteProjectPath],
         model: resolvedModel,
         resume: sessionId, // Resume previous session

--- a/lib/services/cli/glm.ts
+++ b/lib/services/cli/glm.ts
@@ -416,7 +416,7 @@ async function executeGLM(
     const response = query({
       prompt: promptWithContext,
       options: {
-        cwd: repoPath,
+        workingDirectory: repoPath,
         additionalDirectories: [repoPath],
         model: normalizedModel,
         resume: sessionId,

--- a/lib/services/project-services.ts
+++ b/lib/services/project-services.ts
@@ -1,11 +1,23 @@
 import { prisma } from '@/lib/db/client';
 import type { ProjectServiceConnection } from '@prisma/client';
 
+/** Deserialized service connection with parsed serviceData */
+export interface DeserializedServiceConnection {
+  id: string;
+  projectId: string;
+  provider: string;
+  status: string;
+  serviceData: Record<string, unknown>;
+  createdAt: Date;
+  updatedAt: Date;
+  lastSyncAt: Date | null;
+}
+
 function serializeServiceData(data: Record<string, unknown>): string {
   return JSON.stringify(data ?? {});
 }
 
-function deserializeServiceData(connection: ProjectServiceConnection) {
+function deserializeServiceData(connection: ProjectServiceConnection): DeserializedServiceConnection {
   try {
     return {
       ...connection,
@@ -25,7 +37,7 @@ function deserializeServiceData(connection: ProjectServiceConnection) {
   }
 }
 
-export async function listProjectServices(projectId: string) {
+export async function listProjectServices(projectId: string): Promise<DeserializedServiceConnection[]> {
   const connections = await prisma.projectServiceConnection.findMany({
     where: { projectId },
     orderBy: { createdAt: 'desc' },
@@ -34,7 +46,7 @@ export async function listProjectServices(projectId: string) {
   return connections.map(deserializeServiceData);
 }
 
-export async function getProjectService(projectId: string, provider: string) {
+export async function getProjectService(projectId: string, provider: string): Promise<DeserializedServiceConnection | null> {
   const connection = await prisma.projectServiceConnection.findFirst({
     where: { projectId, provider },
   });
@@ -46,7 +58,7 @@ export async function upsertProjectServiceConnection(
   projectId: string,
   provider: string,
   serviceData: Record<string, unknown>
-) {
+): Promise<DeserializedServiceConnection> {
   const existing = await prisma.projectServiceConnection.findFirst({
     where: { projectId, provider },
   });
@@ -89,7 +101,7 @@ export async function updateProjectServiceData(
   projectId: string,
   provider: string,
   patch: Record<string, unknown>
-) {
+): Promise<DeserializedServiceConnection> {
   const existing = await prisma.projectServiceConnection.findFirst({
     where: { projectId, provider },
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.1.22",
+        "@anthropic-ai/claude-agent-sdk": "^0.1.58",
         "@prisma/client": "^6.1.0",
         "dotenv": "^16.4.5",
         "framer-motion": "^11.11.17",
@@ -59,9 +59,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.1.22.tgz",
-      "integrity": "sha512-lDwbcwh5goRVUHRRqvX9v6Vj38VME1L+QIaLWzdqbK3Lwkkz9PVLNQFRDEyUOSNd9Fm4cAlfQZ0RCVe8tuo9TA==",
+      "version": "0.1.58",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.1.58.tgz",
+      "integrity": "sha512-Gc8YjY734D7qUT4I7eTF/vvu7m2umCKm03OGEZs3fGnqwSzVi0SWfGIkTZn4qLtvEbfojm/qXTRd/9OM2vhi3Q==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
@@ -72,10 +72,88 @@
         "@img/sharp-linux-arm": "^0.33.5",
         "@img/sharp-linux-arm64": "^0.33.5",
         "@img/sharp-linux-x64": "^0.33.5",
+        "@img/sharp-linuxmusl-arm64": "^0.33.5",
+        "@img/sharp-linuxmusl-x64": "^0.33.5",
         "@img/sharp-win32-x64": "^0.33.5"
       },
       "peerDependencies": {
         "zod": "^3.24.1"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
       }
     },
     "node_modules/@develar/schema-utils": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "description": "AI-Powered Web App Builder - Build apps with natural language using Claude Code, Cursor, and more",
   "private": true,
-  "main": "index.js",
+  "main": "electron/main.js",
   "scripts": {
     "dev": "node scripts/run-web.js",
     "dev:web": "node scripts/run-web.js",
@@ -28,7 +28,7 @@
     "postinstall": "npm run ensure:env"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.1.22",
+    "@anthropic-ai/claude-agent-sdk": "^0.1.58",
     "@prisma/client": "^6.1.0",
     "dotenv": "^16.4.5",
     "framer-motion": "^11.11.17",


### PR DESCRIPTION
## Summary
- Update `@anthropic-ai/claude-agent-sdk` from 0.1.22 to 0.1.58
- Update Claude Opus model from 4.1 to 4.5 (`claude-opus-4-5-20251101`)
- Fix CLI query options per SDK API changes

## Changes

### SDK Update
- Upgraded `@anthropic-ai/claude-agent-sdk` to latest version (0.1.58)
- Updated query options: `cwd` → `workingDirectory` per SDK breaking change

### Model Configuration  
- Updated Claude Opus model ID from `claude-opus-4-1-20250805` to `claude-opus-4-5-20251101`
- Updated all related aliases (opus-4-5, opus-4.5, etc.)

### TypeScript Improvements
- Added `DeserializedServiceConnection` interface for type safety
- Added proper return type annotations to project-services functions

### Package.json Fixes
- Corrected main entry point to `electron/main.js`

## Test plan
- [ ] Verify Claude Code CLI integration works with new SDK
- [ ] Test Opus 4.5 model selection and execution
- [ ] Confirm project services work with updated types