### PR TITLE
Fix: Prevent storing GitHub token in .git/config

### DIFF
--- a/lib/services/git.ts
+++ b/lib/services/git.ts
@@ -160,12 +160,18 @@ export function commitAll(repoPath: string, message: string) {
   }
 }
 
-export function pushToRemote(repoPath: string, remoteName = 'origin', branch = 'main') {
+export function pushToRemote(
+  repoPath: string,
+  remoteName = 'origin',
+  branch = 'main',
+  remoteUrl?: string,
+) {
+  const remote = remoteUrl || remoteName;
   try {
-    runGit(['push', '-u', remoteName, branch], repoPath);
+    runGit(['push', '-u', remote, branch], repoPath);
   } catch (error) {
     if (error instanceof GitError) {
-      runGit(['push', '-u', '--force', remoteName, branch], repoPath);
+      runGit(['push', '-u', '--force', remote, branch], repoPath);
     } else {
       throw error;
     }


### PR DESCRIPTION
A critical security vulnerability was identified where the GitHub access token was being stored in plaintext within the project's local `.git/config` file. This occurred because the token was embedded directly into the remote URL during repository connection and subsequent push operations.

The code has been modified to no longer store the GitHub token in the remote URL. The `lib/services/github.ts` file was updated to set the remote URL without credentials. For push operations, the authenticated URL is now constructed just-in-time and passed directly to the `git push` command. The `lib/services/git.ts` file was also updated to support this by allowing the `pushToRemote` function to accept a dynamic, authenticated URL for the push, ensuring the token is used for authentication but never written to disk.