### PR TITLE
Claudable Cloud edition (live on Railway)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+.next
+out
+data
+.git
+*.log
+electron
+release
+dist
+.claude
+/server

--- a/.env.cloud.example
+++ b/.env.cloud.example
@@ -1,0 +1,13 @@
+# ── Claudable Cloud — frontend (Next.js) env ────────────────────────────────
+# Add these to .env.local (alongside the existing auto-generated values).
+# All are public (NEXT_PUBLIC_*) — safe to ship to the browser.
+
+NEXT_PUBLIC_SUPABASE_URL=https://YOUR-PROJECT.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+
+# Orchestration backend base URLs.
+NEXT_PUBLIC_BACKEND_URL=http://localhost:8080
+NEXT_PUBLIC_BACKEND_WS_URL=ws://localhost:8080
+
+# Show the "Continue with Google" button on the cloud login page (1 = on).
+NEXT_PUBLIC_ENABLE_GOOGLE_OAUTH=0

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,11 @@ temp/
 # Electron build artifacts (too large for GitHub)
 dist/
 release/
+
+# ============================================================
+# Claudable Cloud (server/)
+# ============================================================
+server/node_modules/
+server/dist/
+server/.env
+.env.cloud.local

--- a/.railwayignore
+++ b/.railwayignore
@@ -1,0 +1,12 @@
+assets
+node_modules
+.next
+out
+data
+.git
+electron
+release
+dist
+.claude
+*.log
+/server

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Claudable is an AI web-app builder: a Next.js 15 (App Router) application that drives external AI coding-agent CLIs (Claude Code, Codex, Cursor, Qwen, GLM) to scaffold and edit *generated user projects*, then runs each generated project in a live preview server. The Claudable app itself, the agent orchestration, and the generated apps are three distinct layers — keep them straight when editing.
+
+> **Two editions in this repo.** The original **desktop** app (this Next.js root + Electron + Prisma/SQLite, agents running on the user's machine) and a newer **cloud** edition (`server/` — a Node/TS backend that runs Claude Code inside per-project Docker containers, backed by Supabase). The cloud backend is independent of the Next.js API routes/Prisma; don't cross-wire them. Cloud entry points: [CLOUD_README.md](CLOUD_README.md), [CLOUD_BUILD_PROMPTS.md](CLOUD_BUILD_PROMPTS.md), [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md). The cloud frontend integration lives in `lib/cloud/` (isolated, additive). Build/check the backend from `server/` (`npm run type-check`, `npm run dev`).
+
+## Commands
+
+```bash
+npm install          # also runs scripts/setup-env.js (postinstall): creates .env/.env.local, picks ports, ENCRYPTION_KEY
+npm run dev          # scripts/run-web.js: sets up env, runs `prisma db push` if needed, starts `next dev`
+npm run dev:desktop  # Electron shell (scripts/run-desktop.js)
+npm run build        # next build (output: 'standalone')
+npm run lint         # next lint
+npm run type-check   # tsc --noEmit  -- there is no test suite; this + lint are the checks
+```
+
+Prisma / DB (SQLite at `data/cc.db`):
+```bash
+npm run prisma:generate   # regenerate client after editing prisma/schema.prisma
+npm run prisma:push       # apply schema to the DB (dev uses db push, not migrations)
+npm run prisma:studio
+npm run prisma:reset      # drop + recreate DB (destructive; fixes schema drift after upgrades)
+npm run db:backup         # data/backups/cc_backup_<ts>.db
+```
+
+There are **no automated tests**. Verify changes with `npm run type-check` and `npm run lint`, and by exercising flows in the running app.
+
+## Ports & environment
+
+- `scripts/setup-env.js` is the source of truth for env. It auto-generates `.env` + `.env.local`, choosing the Claudable web port (default 3000, scans up to ~3099) and reserving a **separate** pool (`PREVIEW_PORT_START`..`PREVIEW_PORT_END`, default 3100–3999) for per-project preview servers. Don't hardcode ports — the web app and previews must not collide.
+- Generated user projects live under `PROJECTS_DIR` (default `./data/projects/<projectId>`); a project's `repoPath` overrides this.
+- `ENCRYPTION_KEY` (hex) backs AES-256-CBC encryption of env vars in `lib/crypto.ts`. Service tokens (`ServiceToken`) are stored plaintext — this is local-dev-only by design.
+
+## Architecture
+
+**Request → agent → preview flow.** The UI calls `POST /api/chat/[project_id]/act` ([app/api/chat/[project_id]/act/route.ts](app/api/chat/[project_id]/act/route.ts)). That route normalizes the instruction + image attachments, persists a `UserRequest` and user `Message`, auto-starts the preview, then **dispatches to a CLI adapter** based on `cliPreference` (`claude` | `codex` | `cursor` | `qwen` | `glm`). It fires the adapter asynchronously (does not await) and returns a `requestId` immediately. Each adapter exposes the same pair: `initializeNextJsProject(...)` for the first prompt and `applyChanges(...)` for follow-ups.
+
+**CLI adapters** live in [lib/services/cli/](lib/services/cli/) (`claude.ts`, `codex.ts`, `cursor.ts`, `qwen.ts`, `glm.ts`). Each one spawns/streams its respective external CLI, parses that CLI's distinct event format, and normalizes tool actions into a common vocabulary (`Read`/`Created`/`Edited`/`Deleted`/`Executed`/`Searched`/`Generated`). Only `claude` and `cursor` track resumable sessions (`activeClaudeSessionId` / `activeCursorSessionId` on `Project`). When changing agent behavior, mirror the change across all adapters — the dispatch in `act/route.ts` assumes a uniform interface. The agents are *external CLIs the user has logged into*, not the `@anthropic-ai/claude-agent-sdk` import alone.
+
+**Real-time output** flows through two transports that mirror each other. `streamManager` ([lib/services/stream.ts](lib/services/stream.ts), SSE) and `websocketManager` ([lib/server/websocket-manager.ts](lib/server/websocket-manager.ts)) are both per-project singletons stored on `globalThis` to survive Next.js HMR/route reloads. `streamManager.publish()` writes to SSE clients **and** calls `websocketManager.broadcast()`, so adapters publish once and both transports get it. The WebSocket server is bootstrapped lazily in the Pages-router endpoint [pages/api/ws/[projectId].ts](pages/api/ws/[projectId].ts), which hooks the HTTP `upgrade` event (only `/api/ws/*`; HMR upgrades pass through). When adding a singleton manager, follow the `globalThis.__claudable_*__` pattern or it will be re-instantiated on every reload.
+
+**Preview servers.** `previewManager` ([lib/services/preview.ts](lib/services/preview.ts)) spawns one dev server per generated project (detects npm/pnpm/yarn/bun), allocates a port from the preview pool, scaffolds a basic Next app if the directory is empty, and tails logs. Lifecycle is driven by `app/api/projects/[project_id]/preview/{start,stop,status}`.
+
+**Data layer.** Prisma + SQLite. The Prisma client is a `globalThis` singleton in [lib/db/client.ts](lib/db/client.ts). Schema ([prisma/schema.prisma](prisma/schema.prisma)) centers on `Project` (with per-CLI session IDs, `preferredCli`, `selectedModel`) and its cascades: `Message`, `Session`, `EnvVar` (encrypted), `Commit`, `ToolUsage`, `UserRequest`, `ProjectServiceConnection`. Dev uses `prisma db push` (no migration history) — after schema edits run `prisma:generate` + `prisma:push`; if a teammate hits drift, `prisma:reset`.
+
+**Service integrations** ([lib/services/](lib/services/)): `github.ts`, `vercel.ts`, `supabase.ts` push generated projects to those platforms. Tokens come from the `ServiceToken` table; per-project links are stored as `ProjectServiceConnection` rows with a JSON `serviceData` blob (shape documented inline in the schema).
+
+**Model registries.** [lib/constants/](lib/constants/) (`claudeModels.ts`, `codexModels.ts`, `cursorModels.ts`, `qwenModels.ts`, `glmModels.ts`, aggregated by `cliModels.ts`) own model IDs, defaults, and normalization (`normalizeModelId`, `getDefaultModelForCli`). Add or rename a model here, not inline in adapters.
+
+## Conventions
+
+- Path alias `@/*` maps to repo root; `@/types/{shared,client,server,backend}` have dedicated mappings (see [tsconfig.json](tsconfig.json)).
+- Server-only modules are kept out of the client bundle via the webpack `fs/path/os: false` fallback in [next.config.js](next.config.js). API routes that spawn processes or touch the DB set `runtime = 'nodejs'` and `dynamic = 'force-dynamic'` — keep that on new server routes.
+- `react-icons` is stubbed in [stubs/](stubs/) (`react-icons-fa/si/vsc`) to trim bundle size; import icons through the existing stub pattern rather than pulling the full package.
+- Frontend: App Router pages in [app/](app/), shared UI in [components/](components/) (`chat/`, `settings/`, `modals/`, `layout/`), React context in [contexts/](contexts/), data hooks in [hooks/](hooks/) (`useCLI`, `useWebSocket`, `useUserRequests`).

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,39 @@
+# Claudable Cloud — frontend (Next.js) image for Railway.
+# Builds the App Router app in standalone mode and serves it. Public config is
+# inlined at build time (NEXT_PUBLIC_*); these are all publishable values.
+FROM node:22-bookworm-slim AS build
+WORKDIR /app
+ENV NEXT_TELEMETRY_DISABLED=1
+# Dummy DB url so Prisma client construction during `next build` doesn't fail
+# (the cloud UI doesn't use Prisma; the desktop API routes just need it to compile).
+ENV DATABASE_URL="file:/tmp/build.db"
+
+COPY package.json package-lock.json ./
+# Skip postinstall (local env setup); install dev deps too (need prisma + next).
+RUN npm ci --ignore-scripts
+COPY . .
+RUN npx prisma generate
+
+# Public build-time config (inlined into the client bundle).
+ARG NEXT_PUBLIC_SUPABASE_URL="https://nmscsqgvrircyfayynzs.supabase.co"
+ARG NEXT_PUBLIC_SUPABASE_ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5tc2NzcWd2cmlyY3lmYXl5bnpzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODI4MzQ1MjUsImV4cCI6MjA5ODQxMDUyNX0.ut90vB7X_e_jD7FCdekU6CZyivRync70qGO_5D6t-cA"
+ARG NEXT_PUBLIC_BACKEND_URL="https://claudable-server-production.up.railway.app"
+ARG NEXT_PUBLIC_BACKEND_WS_URL="wss://claudable-server-production.up.railway.app"
+ARG NEXT_PUBLIC_ENABLE_GOOGLE_OAUTH="0"
+ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL \
+    NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY \
+    NEXT_PUBLIC_BACKEND_URL=$NEXT_PUBLIC_BACKEND_URL \
+    NEXT_PUBLIC_BACKEND_WS_URL=$NEXT_PUBLIC_BACKEND_WS_URL \
+    NEXT_PUBLIC_ENABLE_GOOGLE_OAUTH=$NEXT_PUBLIC_ENABLE_GOOGLE_OAUTH
+
+RUN npm run build
+
+FROM node:22-bookworm-slim AS runtime
+WORKDIR /app
+ENV NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 HOSTNAME=0.0.0.0
+# Next.js standalone output bundles a minimal server + traced deps.
+COPY --from=build /app/.next/standalone ./
+COPY --from=build /app/.next/static ./.next/static
+COPY --from=build /app/public ./public
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/app/cloud/ApiKeyPanel.tsx
+++ b/app/cloud/ApiKeyPanel.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { cloudApi } from '@/lib/cloud/api';
+
+/**
+ * BYOK panel: lets the user store their own Anthropic API key (write-only).
+ * The key is never read back from the server — we only show configured state.
+ * onChange notifies the parent so it can gate project creation until a key exists.
+ */
+export function ApiKeyPanel({ onChange }: { onChange?: (configured: boolean) => void }) {
+  const [configured, setConfigured] = useState<boolean | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const { configured } = await cloudApi.getKeyStatus();
+      setConfigured(configured);
+      onChange?.(configured);
+    } catch {
+      setConfigured(false);
+    }
+  }, [onChange]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const save = async () => {
+    if (!value.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await cloudApi.setKey(value.trim());
+      setValue('');
+      setEditing(false);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save key');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const remove = async () => {
+    setBusy(true);
+    try {
+      await cloudApi.deleteKey();
+      await refresh();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const unset = configured === false;
+
+  return (
+    <div
+      className={`mb-6 rounded-xl border p-4 ${
+        unset ? 'border-yellow-500/40 bg-yellow-500/5' : 'border-bolt-border-color bg-bolt-bg-secondary'
+      }`}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold">Anthropic API key</h2>
+          <p className="text-xs text-bolt-text-secondary">
+            {configured === null
+              ? 'Checking…'
+              : configured
+                ? 'Configured — your key is used to run Claude Code. It is stored encrypted and never shown again.'
+                : 'Required to generate apps. Get one at console.anthropic.com → API Keys.'}
+          </p>
+        </div>
+        {configured && !editing && (
+          <div className="flex shrink-0 gap-2">
+            <span className="rounded bg-green-500/15 px-2 py-1 text-xs text-green-400">✓ Set</span>
+            <button
+              onClick={() => setEditing(true)}
+              className="rounded-lg border border-bolt-border-color px-2 py-1 text-xs hover:bg-bolt-bg-tertiary"
+            >
+              Replace
+            </button>
+            <button
+              onClick={remove}
+              disabled={busy}
+              className="rounded-lg border border-bolt-border-color px-2 py-1 text-xs text-red-400 hover:bg-bolt-bg-tertiary"
+            >
+              Remove
+            </button>
+          </div>
+        )}
+      </div>
+
+      {(unset || editing) && (
+        <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+          <input
+            type="password"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="sk-ant-..."
+            autoComplete="off"
+            className="flex-1 rounded-lg border border-bolt-border-color bg-bolt-bg-tertiary px-3 py-2 text-sm outline-none focus:border-brand-500"
+          />
+          <button
+            onClick={save}
+            disabled={busy || !value.trim()}
+            className="rounded-lg bg-brand-600 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-700 disabled:opacity-50"
+          >
+            {busy ? 'Saving…' : 'Save key'}
+          </button>
+          {editing && (
+            <button
+              onClick={() => {
+                setEditing(false);
+                setValue('');
+              }}
+              className="rounded-lg border border-bolt-border-color px-3 py-2 text-sm hover:bg-bolt-bg-tertiary"
+            >
+              Cancel
+            </button>
+          )}
+        </div>
+      )}
+
+      {error && <p className="mt-2 text-xs text-red-400">{error}</p>}
+    </div>
+  );
+}

--- a/app/cloud/[projectId]/page.tsx
+++ b/app/cloud/[projectId]/page.tsx
@@ -1,0 +1,279 @@
+'use client';
+
+import { use, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { RequireAuth } from '@/lib/cloud/RequireAuth';
+import { cloudApi, type CloudMessage, type CloudProject, type FileNode } from '@/lib/cloud/api';
+import { useProjectStream, type StreamEvent } from '@/lib/cloud/useProjectStream';
+
+/** A unified transcript row from either loaded history or a live stream event. */
+interface Row {
+  kind: 'user' | 'assistant' | 'tool' | 'terminal' | 'status' | 'completion';
+  text: string;
+  meta?: { action?: string; filePath?: string; command?: string; ok?: boolean };
+}
+
+function eventToRow(evt: StreamEvent): Row | null {
+  const d = evt.data as Record<string, unknown>;
+  switch (evt.type) {
+    case 'message':
+      return { kind: (d.role as Row['kind']) ?? 'assistant', text: String(d.content ?? '') };
+    case 'tool':
+      if (d.phase === 'result') {
+        return { kind: 'terminal', text: String(d.output ?? '') };
+      }
+      return {
+        kind: 'tool',
+        text: String(d.filePath ?? d.command ?? d.toolName ?? 'tool'),
+        meta: {
+          action: d.action as string | undefined,
+          filePath: d.filePath as string | undefined,
+          command: d.command as string | undefined,
+        },
+      };
+    case 'terminal':
+      return { kind: 'terminal', text: String(d.line ?? '') };
+    case 'status':
+      return { kind: 'status', text: String(d.detail ?? d.status ?? '') };
+    case 'completion':
+      return {
+        kind: 'completion',
+        text: d.ok ? 'Run completed' : `Run failed: ${String(d.error ?? 'unknown')}`,
+        meta: { ok: Boolean(d.ok) },
+      };
+    default:
+      return null;
+  }
+}
+
+function Workspace({ projectId }: { projectId: string }) {
+  const router = useRouter();
+  const [project, setProject] = useState<CloudProject | null>(null);
+  const [history, setHistory] = useState<Row[]>([]);
+  const [instruction, setInstruction] = useState('');
+  const [sending, setSending] = useState(false);
+  const [files, setFiles] = useState<FileNode[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const { events, state } = useProjectStream(projectId);
+
+  const liveRows = useMemo(
+    () => events.map(eventToRow).filter((r): r is Row => r !== null),
+    [events],
+  );
+  const rows = useMemo(() => [...history, ...liveRows], [history, liveRows]);
+
+  const loadProject = useCallback(async () => {
+    try {
+      const [{ project }, { messages }] = await Promise.all([
+        cloudApi.getProject(projectId),
+        cloudApi.listMessages(projectId),
+      ]);
+      setProject(project);
+      setHistory(
+        messages.map((m: CloudMessage): Row => {
+          const meta = (m.metadata ?? {}) as Record<string, unknown>;
+          if (m.role === 'tool') {
+            return {
+              kind: 'tool',
+              text: m.message,
+              meta: { action: meta.action as string, filePath: meta.filePath as string },
+            };
+          }
+          return { kind: m.role === 'user' ? 'user' : 'assistant', text: m.message };
+        }),
+      );
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load project');
+    }
+  }, [projectId]);
+
+  const loadFiles = useCallback(async () => {
+    try {
+      const { files } = await cloudApi.listFiles(projectId);
+      setFiles(files);
+    } catch {
+      /* workspace may not be provisioned yet */
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    void loadProject();
+    void loadFiles();
+  }, [loadProject, loadFiles]);
+
+  // Auto-scroll + refresh files when a run completes.
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+    const last = events[events.length - 1];
+    if (last?.type === 'completion') {
+      void loadFiles();
+      setSending(false);
+    }
+  }, [events, loadFiles]);
+
+  const send = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const text = instruction.trim();
+    if (!text || sending) return;
+    setSending(true);
+    setError(null);
+    setInstruction('');
+    try {
+      await cloudApi.act(projectId, { instruction: text });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to send');
+      setSending(false);
+    }
+  };
+
+  const download = async () => {
+    try {
+      const { url } = await cloudApi.getDownloadUrl(projectId);
+      window.open(url, '_blank');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Download not available yet');
+    }
+  };
+
+  return (
+    <div className="flex h-screen flex-col">
+      {/* Top bar */}
+      <header className="flex items-center justify-between border-b border-bolt-border-color px-5 py-3">
+        <div className="flex items-center gap-3">
+          <button onClick={() => router.push('/cloud')} className="text-sm text-bolt-text-secondary hover:text-bolt-text-primary">
+            ← Projects
+          </button>
+          <h1 className="font-semibold">{project?.project_name ?? 'Workspace'}</h1>
+          <span
+            className={`h-2 w-2 rounded-full ${state === 'open' ? 'bg-green-400' : state === 'connecting' ? 'bg-yellow-400' : 'bg-bolt-text-tertiary'}`}
+            title={`stream: ${state}`}
+          />
+        </div>
+        <div className="flex gap-2">
+          <button onClick={download} className="rounded-lg border border-bolt-border-color px-3 py-1.5 text-sm hover:bg-bolt-bg-tertiary">
+            Download
+          </button>
+          <button
+            onClick={() => cloudApi.stop(projectId).then(loadProject)}
+            className="rounded-lg border border-bolt-border-color px-3 py-1.5 text-sm hover:bg-bolt-bg-tertiary"
+          >
+            Stop
+          </button>
+        </div>
+      </header>
+
+      <div className="flex min-h-0 flex-1">
+        {/* Transcript */}
+        <section className="flex min-w-0 flex-1 flex-col">
+          <div ref={scrollRef} className="flex-1 space-y-2 overflow-y-auto px-5 py-4">
+            {rows.length === 0 && (
+              <p className="text-sm text-bolt-text-secondary">
+                Send an instruction below to start Claude Code in your cloud workspace.
+              </p>
+            )}
+            {rows.map((row, i) => (
+              <TranscriptRow key={i} row={row} />
+            ))}
+          </div>
+
+          {error && <p className="px-5 pb-2 text-sm text-red-400">{error}</p>}
+
+          <form onSubmit={send} className="border-t border-bolt-border-color p-3">
+            <div className="flex gap-2">
+              <input
+                value={instruction}
+                onChange={(e) => setInstruction(e.target.value)}
+                placeholder="Ask Claude Code to build or change something…"
+                className="flex-1 rounded-lg border border-bolt-border-color bg-bolt-bg-tertiary px-3 py-2 text-sm outline-none focus:border-brand-500"
+              />
+              <button
+                type="submit"
+                disabled={sending}
+                className="rounded-lg bg-brand-600 px-5 py-2 text-sm font-semibold text-white hover:bg-brand-700 disabled:opacity-50"
+              >
+                {sending ? 'Running…' : 'Send'}
+              </button>
+            </div>
+          </form>
+        </section>
+
+        {/* File tree */}
+        <aside className="hidden w-72 shrink-0 overflow-y-auto border-l border-bolt-border-color p-3 lg:block">
+          <div className="mb-2 flex items-center justify-between">
+            <h2 className="text-xs font-semibold uppercase tracking-wide text-bolt-text-tertiary">Files</h2>
+            <button onClick={loadFiles} className="text-xs text-bolt-text-secondary hover:text-bolt-text-primary">
+              Refresh
+            </button>
+          </div>
+          {files.length === 0 ? (
+            <p className="text-xs text-bolt-text-tertiary">No files yet.</p>
+          ) : (
+            <FileTree nodes={files} />
+          )}
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function TranscriptRow({ row }: { row: Row }) {
+  if (row.kind === 'user') {
+    return (
+      <div className="flex justify-end">
+        <div className="max-w-[80%] rounded-2xl bg-brand-600 px-3 py-2 text-sm text-white">{row.text}</div>
+      </div>
+    );
+  }
+  if (row.kind === 'assistant') {
+    return (
+      <div className="max-w-[85%] whitespace-pre-wrap rounded-2xl bg-bolt-bg-secondary px-3 py-2 text-sm">
+        {row.text}
+      </div>
+    );
+  }
+  if (row.kind === 'tool') {
+    return (
+      <div className="flex items-center gap-2 text-xs text-bolt-text-secondary">
+        <span className="rounded bg-brand-500/15 px-1.5 py-0.5 text-brand-400">{row.meta?.action ?? 'Tool'}</span>
+        <span className="font-mono">{row.meta?.command ?? row.meta?.filePath ?? row.text}</span>
+      </div>
+    );
+  }
+  if (row.kind === 'terminal') {
+    return (
+      <pre className="overflow-x-auto rounded-lg bg-black/40 px-3 py-2 text-xs text-bolt-text-secondary">{row.text}</pre>
+    );
+  }
+  if (row.kind === 'completion') {
+    return (
+      <div className={`py-1 text-center text-xs ${row.meta?.ok ? 'text-green-400' : 'text-red-400'}`}>— {row.text} —</div>
+    );
+  }
+  return <div className="text-xs italic text-bolt-text-tertiary">{row.text}</div>;
+}
+
+function FileTree({ nodes, depth = 0 }: { nodes: FileNode[]; depth?: number }) {
+  return (
+    <ul className="space-y-0.5 text-xs">
+      {nodes.map((node) => (
+        <li key={node.path}>
+          <div style={{ paddingLeft: depth * 12 }} className="truncate py-0.5 text-bolt-text-secondary">
+            {node.type === 'dir' ? '📁' : '📄'} {node.name}
+          </div>
+          {node.children && node.children.length > 0 && <FileTree nodes={node.children} depth={depth + 1} />}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default function WorkspacePage({ params }: { params: Promise<{ projectId: string }> }) {
+  const { projectId } = use(params);
+  return (
+    <RequireAuth>
+      <Workspace projectId={projectId} />
+    </RequireAuth>
+  );
+}

--- a/app/cloud/layout.tsx
+++ b/app/cloud/layout.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { CloudAuthProvider } from '@/lib/cloud/AuthProvider';
+
+/**
+ * Cloud edition layout. Nests inside the root layout but provides its own
+ * Supabase-backed auth context for everything under /cloud.
+ */
+export default function CloudLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <CloudAuthProvider>
+      <div className="min-h-screen bg-bolt-bg-primary text-bolt-text-primary">{children}</div>
+    </CloudAuthProvider>
+  );
+}

--- a/app/cloud/login/page.tsx
+++ b/app/cloud/login/page.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useCloudAuth } from '@/lib/cloud/AuthProvider';
+
+const GOOGLE_ENABLED = process.env.NEXT_PUBLIC_ENABLE_GOOGLE_OAUTH === '1';
+
+export default function CloudLoginPage() {
+  const router = useRouter();
+  const { user, loading, signInWithPassword, signUpWithPassword, signInWithGoogle } = useCloudAuth();
+  const [mode, setMode] = useState<'signin' | 'signup'>('signin');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!loading && user) router.replace('/cloud');
+  }, [loading, user, router]);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setNotice(null);
+    setBusy(true);
+    try {
+      if (mode === 'signin') {
+        await signInWithPassword(email, password);
+        router.replace('/cloud');
+      } else {
+        const { needsConfirmation } = await signUpWithPassword(email, password);
+        if (needsConfirmation) {
+          setNotice('Check your email to confirm your account, then sign in.');
+          setMode('signin');
+        } else {
+          router.replace('/cloud');
+        }
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Authentication failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="w-full max-w-sm rounded-2xl border border-bolt-border-color bg-bolt-bg-secondary p-8 shadow-xl">
+        <h1 className="mb-1 text-2xl font-bold">Claudable Cloud</h1>
+        <p className="mb-6 text-sm text-bolt-text-secondary">
+          {mode === 'signin' ? 'Sign in to build apps in the browser.' : 'Create your account.'}
+        </p>
+
+        <form onSubmit={submit} className="space-y-3">
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="you@example.com"
+            className="w-full rounded-lg border border-bolt-border-color bg-bolt-bg-tertiary px-3 py-2 text-sm outline-none focus:border-brand-500"
+          />
+          <input
+            type="password"
+            required
+            minLength={6}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Password"
+            className="w-full rounded-lg border border-bolt-border-color bg-bolt-bg-tertiary px-3 py-2 text-sm outline-none focus:border-brand-500"
+          />
+
+          {error && <p className="text-sm text-red-400">{error}</p>}
+          {notice && <p className="text-sm text-green-400">{notice}</p>}
+
+          <button
+            type="submit"
+            disabled={busy}
+            className="w-full rounded-lg bg-brand-600 py-2 text-sm font-semibold text-white transition hover:bg-brand-700 disabled:opacity-50"
+          >
+            {busy ? 'Please wait…' : mode === 'signin' ? 'Sign in' : 'Sign up'}
+          </button>
+        </form>
+
+        {GOOGLE_ENABLED && (
+          <button
+            onClick={() => signInWithGoogle().catch((e) => setError(e.message))}
+            className="mt-3 w-full rounded-lg border border-bolt-border-color py-2 text-sm font-medium hover:bg-bolt-bg-tertiary"
+          >
+            Continue with Google
+          </button>
+        )}
+
+        <button
+          onClick={() => {
+            setMode((m) => (m === 'signin' ? 'signup' : 'signin'));
+            setError(null);
+            setNotice(null);
+          }}
+          className="mt-5 w-full text-center text-xs text-bolt-text-secondary hover:text-bolt-text-primary"
+        >
+          {mode === 'signin' ? "Don't have an account? Sign up" : 'Already have an account? Sign in'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/cloud/page.tsx
+++ b/app/cloud/page.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { RequireAuth } from '@/lib/cloud/RequireAuth';
+import { useCloudAuth } from '@/lib/cloud/AuthProvider';
+import { cloudApi, type CloudProject } from '@/lib/cloud/api';
+import { ApiKeyPanel } from './ApiKeyPanel';
+
+function statusColor(status: string): string {
+  switch (status) {
+    case 'running':
+    case 'executing':
+      return 'bg-green-500/20 text-green-400';
+    case 'error':
+      return 'bg-red-500/20 text-red-400';
+    case 'provisioning':
+      return 'bg-yellow-500/20 text-yellow-400';
+    default:
+      return 'bg-bolt-bg-tertiary text-bolt-text-secondary';
+  }
+}
+
+function Dashboard() {
+  const router = useRouter();
+  const { user, signOut } = useCloudAuth();
+  const [projects, setProjects] = useState<CloudProject[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [name, setName] = useState('');
+  const [prompt, setPrompt] = useState('');
+  const [keyConfigured, setKeyConfigured] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const { projects } = await cloudApi.listProjects();
+      setProjects(projects);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load projects');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const create = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    setCreating(true);
+    setError(null);
+    try {
+      const { project } = await cloudApi.createProject({
+        projectName: name.trim(),
+        initialPrompt: prompt.trim() || undefined,
+      });
+      // Kick off the initial generation if a prompt was supplied.
+      if (prompt.trim()) {
+        await cloudApi.act(project.id, { instruction: prompt.trim(), isInitialPrompt: true });
+      }
+      router.push(`/cloud/${project.id}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to create project');
+      setCreating(false);
+    }
+  };
+
+  const remove = async (id: string) => {
+    if (!confirm('Delete this project and its workspace?')) return;
+    await cloudApi.deleteProject(id).catch(() => {});
+    setProjects((p) => p.filter((x) => x.id !== id));
+  };
+
+  return (
+    <div className="mx-auto max-w-5xl px-6 py-10">
+      <header className="mb-8 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Your Projects</h1>
+          <p className="text-sm text-bolt-text-secondary">{user?.email}</p>
+        </div>
+        <button
+          onClick={() => signOut()}
+          className="rounded-lg border border-bolt-border-color px-3 py-1.5 text-sm hover:bg-bolt-bg-tertiary"
+        >
+          Sign out
+        </button>
+      </header>
+
+      <ApiKeyPanel onChange={setKeyConfigured} />
+
+      <form
+        onSubmit={create}
+        className="mb-8 rounded-2xl border border-bolt-border-color bg-bolt-bg-secondary p-5"
+      >
+        <h2 className="mb-3 text-sm font-semibold">New project</h2>
+        {!keyConfigured && (
+          <p className="mb-3 text-xs text-yellow-400">Add your Anthropic API key above to start generating.</p>
+        )}
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Project name"
+            className="w-full rounded-lg border border-bolt-border-color bg-bolt-bg-tertiary px-3 py-2 text-sm outline-none focus:border-brand-500 sm:w-56"
+          />
+          <input
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            placeholder='Describe your app — e.g. "Build a Todo app with dark mode"'
+            className="w-full flex-1 rounded-lg border border-bolt-border-color bg-bolt-bg-tertiary px-3 py-2 text-sm outline-none focus:border-brand-500"
+          />
+          <button
+            type="submit"
+            disabled={creating || !keyConfigured}
+            title={!keyConfigured ? 'Add your Anthropic API key first' : undefined}
+            className="rounded-lg bg-brand-600 px-5 py-2 text-sm font-semibold text-white hover:bg-brand-700 disabled:opacity-50"
+          >
+            {creating ? 'Creating…' : 'Create'}
+          </button>
+        </div>
+      </form>
+
+      {error && <p className="mb-4 text-sm text-red-400">{error}</p>}
+
+      {loading ? (
+        <p className="text-sm text-bolt-text-secondary">Loading projects…</p>
+      ) : projects.length === 0 ? (
+        <p className="text-sm text-bolt-text-secondary">No projects yet. Create one above.</p>
+      ) : (
+        <ul className="grid gap-3 sm:grid-cols-2">
+          {projects.map((p) => (
+            <li
+              key={p.id}
+              className="group rounded-xl border border-bolt-border-color bg-bolt-bg-secondary p-4 transition hover:border-brand-500"
+            >
+              <div className="flex items-start justify-between">
+                <button
+                  onClick={() => router.push(`/cloud/${p.id}`)}
+                  className="text-left font-semibold hover:text-brand-400"
+                >
+                  {p.project_name}
+                </button>
+                <span className={`rounded px-2 py-0.5 text-xs ${statusColor(p.status)}`}>{p.status}</span>
+              </div>
+              {p.description && (
+                <p className="mt-1 line-clamp-2 text-xs text-bolt-text-secondary">{p.description}</p>
+              )}
+              <div className="mt-3 flex gap-3 text-xs text-bolt-text-tertiary">
+                <button onClick={() => router.push(`/cloud/${p.id}`)} className="hover:text-brand-400">
+                  Open
+                </button>
+                <button onClick={() => remove(p.id)} className="hover:text-red-400">
+                  Delete
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default function CloudHome() {
+  return (
+    <RequireAuth>
+      <Dashboard />
+    </RequireAuth>
+  );
+}

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,30 @@
+# Claudable Cloud — backend on a single Docker host.
+# The backend container mounts the host Docker socket so its SessionManager can
+# launch sibling workspace containers on the same daemon.
+services:
+  server:
+    build:
+      context: ../server
+      dockerfile: Dockerfile
+    image: claudable-cloud-server:latest
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    environment:
+      NODE_ENV: production
+      PORT: "8080"
+      SUPABASE_URL: ${SUPABASE_URL}
+      SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY}
+      SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY}
+      SUPABASE_STORAGE_BUCKET: ${SUPABASE_STORAGE_BUCKET:-project-artifacts}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      CLAUDE_DEFAULT_MODEL: ${CLAUDE_DEFAULT_MODEL:-claude-sonnet-4-6}
+      WORKSPACE_IMAGE: ${WORKSPACE_IMAGE:-claudable-workspace:latest}
+      MAX_CONCURRENT_WORKSPACES: ${MAX_CONCURRENT_WORKSPACES:-10}
+      WORKSPACES_ROOT: /var/lib/claudable/workspaces
+      FRONTEND_ORIGIN: ${FRONTEND_ORIGIN:-*}
+    volumes:
+      # Access to the host Docker daemon to manage workspace containers.
+      - /var/run/docker.sock:/var/run/docker.sock
+      # Workspaces must live on the HOST path so sibling containers can bind-mount them.
+      - /var/lib/claudable/workspaces:/var/lib/claudable/workspaces

--- a/lib/cloud/AuthProvider.tsx
+++ b/lib/cloud/AuthProvider.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+/**
+ * Cloud auth context — wraps Supabase Auth for the cloud UI under /cloud.
+ * Independent of the desktop AuthContext.
+ */
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+import type { Session, User } from '@supabase/supabase-js';
+import { getSupabaseBrowserClient } from './supabase-client';
+
+interface CloudAuthvalue {
+  user: User | null;
+  session: Session | null;
+  loading: boolean;
+  signInWithPassword: (email: string, password: string) => Promise<void>;
+  signUpWithPassword: (email: string, password: string) => Promise<{ needsConfirmation: boolean }>;
+  signInWithGoogle: () => Promise<void>;
+  signOut: () => Promise<void>;
+}
+
+const Ctx = createContext<CloudAuthvalue | null>(null);
+
+export function useCloudAuth(): CloudAuthvalue {
+  const ctx = useContext(Ctx);
+  if (!ctx) throw new Error('useCloudAuth must be used within CloudAuthProvider');
+  return ctx;
+}
+
+export function CloudAuthProvider({ children }: { children: ReactNode }) {
+  // Client is created in the browser only (never during SSR/prerender, where
+  // NEXT_PUBLIC env vars may be absent and the constructor would throw).
+  const [supabase, setSupabase] = useState<ReturnType<typeof getSupabaseBrowserClient> | null>(null);
+  const [session, setSession] = useState<Session | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setSupabase(getSupabaseBrowserClient());
+  }, []);
+
+  useEffect(() => {
+    if (!supabase) return;
+    supabase.auth.getSession().then(({ data }) => {
+      setSession(data.session);
+      setLoading(false);
+    });
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, s) => setSession(s));
+    return () => sub.subscription.unsubscribe();
+  }, [supabase]);
+
+  const value = useMemo<CloudAuthvalue>(() => {
+    const requireClient = () => {
+      if (!supabase) throw new Error('Auth client not ready');
+      return supabase;
+    };
+    return {
+      user: session?.user ?? null,
+      session,
+      loading,
+      signInWithPassword: async (email, password) => {
+        const { error } = await requireClient().auth.signInWithPassword({ email, password });
+        if (error) throw error;
+      },
+      signUpWithPassword: async (email, password) => {
+        const { data, error } = await requireClient().auth.signUp({ email, password });
+        if (error) throw error;
+        return { needsConfirmation: !data.session };
+      },
+      signInWithGoogle: async () => {
+        const { error } = await requireClient().auth.signInWithOAuth({
+          provider: 'google',
+          options: { redirectTo: `${window.location.origin}/cloud` },
+        });
+        if (error) throw error;
+      },
+      signOut: async () => {
+        await requireClient().auth.signOut();
+      },
+    };
+  }, [supabase, session, loading]);
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}

--- a/lib/cloud/RequireAuth.tsx
+++ b/lib/cloud/RequireAuth.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useCloudAuth } from './AuthProvider';
+
+/** Gate a cloud page behind a Supabase session; redirect to /cloud/login otherwise. */
+export function RequireAuth({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const { user, loading } = useCloudAuth();
+
+  useEffect(() => {
+    if (!loading && !user) router.replace('/cloud/login');
+  }, [loading, user, router]);
+
+  if (loading || !user) {
+    return (
+      <div className="flex min-h-screen items-center justify-center text-sm text-bolt-text-secondary">
+        Loading…
+      </div>
+    );
+  }
+  return <>{children}</>;
+}

--- a/lib/cloud/api.ts
+++ b/lib/cloud/api.ts
@@ -1,0 +1,110 @@
+/**
+ * Typed REST client for the Claudable Cloud orchestration backend.
+ * Every request carries the Supabase access token as a Bearer credential.
+ */
+import { getAccessToken } from './supabase-client';
+
+const BASE = process.env.NEXT_PUBLIC_BACKEND_URL ?? '';
+
+export interface CloudProject {
+  id: string;
+  user_id: string;
+  project_name: string;
+  description: string | null;
+  status: string;
+  workspace_path: string | null;
+  claude_session_id: string | null;
+  selected_model: string | null;
+  latest_artifact_path: string | null;
+  created_at: string;
+  updated_at: string;
+  last_active_at: string;
+}
+
+export interface CloudMessage {
+  id: string;
+  project_id: string;
+  role: 'user' | 'assistant' | 'system' | 'tool';
+  message: string;
+  metadata: Record<string, unknown> | null;
+  request_id: string | null;
+  created_at: string;
+}
+
+export interface FileNode {
+  name: string;
+  path: string;
+  type: 'file' | 'dir';
+  size?: number;
+  children?: FileNode[];
+}
+
+async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const token = await getAccessToken();
+  const res = await fetch(`${BASE}${path}`, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(init.headers ?? {}),
+    },
+  });
+  if (!res.ok) {
+    let detail: unknown;
+    try {
+      detail = await res.json();
+    } catch {
+      detail = await res.text().catch(() => res.statusText);
+    }
+    const message =
+      (detail as { error?: { message?: string } })?.error?.message ?? `Request failed (${res.status})`;
+    throw new Error(message);
+  }
+  return res.json() as Promise<T>;
+}
+
+export const cloudApi = {
+  listProjects: () => request<{ projects: CloudProject[] }>('/api/projects'),
+
+  createProject: (input: { projectName: string; description?: string; initialPrompt?: string }) =>
+    request<{ project: CloudProject }>('/api/projects', {
+      method: 'POST',
+      body: JSON.stringify(input),
+    }),
+
+  getProject: (id: string) => request<{ project: CloudProject }>(`/api/projects/${id}`),
+
+  deleteProject: (id: string) =>
+    request<{ ok: true }>(`/api/projects/${id}`, { method: 'DELETE' }),
+
+  act: (id: string, input: { instruction: string; isInitialPrompt?: boolean; selectedModel?: string }) =>
+    request<{ ok: true; requestId: string; userMessageId: string }>(`/api/projects/${id}/act`, {
+      method: 'POST',
+      body: JSON.stringify(input),
+    }),
+
+  listMessages: (id: string) => request<{ messages: CloudMessage[] }>(`/api/projects/${id}/messages`),
+
+  listFiles: (id: string) => request<{ files: FileNode[] }>(`/api/projects/${id}/files`),
+
+  readFile: (id: string, path: string) =>
+    request<{ path: string; content: string }>(
+      `/api/projects/${id}/files/content?path=${encodeURIComponent(path)}`,
+    ),
+
+  stop: (id: string) => request<{ ok: true }>(`/api/projects/${id}/stop`, { method: 'POST' }),
+
+  getDownloadUrl: (id: string) => request<{ url: string }>(`/api/projects/${id}/download`),
+
+  // --- BYOK Anthropic API key (write-only; never returned) ---
+  getKeyStatus: () => request<{ configured: boolean }>('/api/settings/anthropic-key'),
+
+  setKey: (apiKey: string) =>
+    request<{ ok: true; configured: true; masked: string }>('/api/settings/anthropic-key', {
+      method: 'PUT',
+      body: JSON.stringify({ apiKey }),
+    }),
+
+  deleteKey: () =>
+    request<{ ok: true; configured: false }>('/api/settings/anthropic-key', { method: 'DELETE' }),
+};

--- a/lib/cloud/supabase-client.ts
+++ b/lib/cloud/supabase-client.ts
@@ -1,0 +1,32 @@
+/**
+ * Browser-side Supabase client for the cloud frontend.
+ *
+ * Uses the publishable anon key only. The access token from this client's
+ * session is what authorizes calls to the orchestration backend.
+ */
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+let cached: SupabaseClient | null = null;
+
+export function getSupabaseBrowserClient(): SupabaseClient {
+  if (cached) return cached;
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !anonKey) {
+    throw new Error(
+      'Missing NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY. ' +
+        'See docs/ENVIRONMENT.md.',
+    );
+  }
+  cached = createClient(url, anonKey, {
+    auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: true },
+  });
+  return cached;
+}
+
+/** Current access token (JWT) or null if signed out. */
+export async function getAccessToken(): Promise<string | null> {
+  const supabase = getSupabaseBrowserClient();
+  const { data } = await supabase.auth.getSession();
+  return data.session?.access_token ?? null;
+}

--- a/lib/cloud/useProjectStream.ts
+++ b/lib/cloud/useProjectStream.ts
@@ -1,0 +1,100 @@
+/**
+ * useProjectStream — subscribe to a project's realtime Claude Code output.
+ *
+ * WebSocket is primary; on failure it falls back to the SSE endpoint. Both
+ * deliver identical event envelopes. Consumers receive a flat list of events
+ * plus the latest connection state.
+ */
+'use client';
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { getAccessToken } from './supabase-client';
+
+export interface StreamEvent {
+  type: string;
+  projectId: string;
+  requestId?: string;
+  seq?: number;
+  ts: string;
+  data: unknown;
+}
+
+type ConnState = 'connecting' | 'open' | 'closed';
+
+const WS_BASE = process.env.NEXT_PUBLIC_BACKEND_WS_URL ?? '';
+const HTTP_BASE = process.env.NEXT_PUBLIC_BACKEND_URL ?? '';
+
+export function useProjectStream(projectId: string | null) {
+  const [events, setEvents] = useState<StreamEvent[]>([]);
+  const [state, setState] = useState<ConnState>('closed');
+  const wsRef = useRef<WebSocket | null>(null);
+  const esRef = useRef<EventSource | null>(null);
+
+  const push = useCallback((evt: StreamEvent) => {
+    setEvents((prev) => [...prev, evt]);
+  }, []);
+
+  useEffect(() => {
+    if (!projectId) return;
+    let cancelled = false;
+
+    const connectSSE = async () => {
+      const token = await getAccessToken();
+      if (cancelled || !token) return;
+      const url = `${HTTP_BASE}/api/projects/${projectId}/stream?access_token=${encodeURIComponent(token)}`;
+      const es = new EventSource(url);
+      esRef.current = es;
+      es.onopen = () => setState('open');
+      es.onmessage = (e) => {
+        try {
+          push(JSON.parse(e.data));
+        } catch {
+          /* ignore malformed */
+        }
+      };
+      es.onerror = () => setState('closed');
+    };
+
+    const connectWS = async () => {
+      const token = await getAccessToken();
+      if (cancelled || !token) return;
+      setState('connecting');
+      const url = `${WS_BASE}/api/ws/${projectId}?access_token=${encodeURIComponent(token)}`;
+      let ws: WebSocket;
+      try {
+        ws = new WebSocket(url);
+      } catch {
+        void connectSSE();
+        return;
+      }
+      wsRef.current = ws;
+      ws.onopen = () => setState('open');
+      ws.onmessage = (e) => {
+        try {
+          push(JSON.parse(e.data));
+        } catch {
+          /* ignore malformed */
+        }
+      };
+      ws.onerror = () => {
+        // Fall back to SSE if the socket never opened.
+        if (ws.readyState !== WebSocket.OPEN) void connectSSE();
+      };
+      ws.onclose = () => setState('closed');
+    };
+
+    void connectWS();
+
+    return () => {
+      cancelled = true;
+      wsRef.current?.close();
+      esRef.current?.close();
+      wsRef.current = null;
+      esRef.current = null;
+    };
+  }, [projectId, push]);
+
+  const clear = useCallback(() => setEvents([]), []);
+
+  return { events, state, clear };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,12 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.68",
         "@prisma/client": "^6.1.0",
+        "@supabase/supabase-js": "^2.108.2",
         "dotenv": "^16.4.5",
         "framer-motion": "^11.11.17",
         "highlight.js": "^11.10.0",
         "lucide-react": "^0.460.0",
-        "next": "^15.5.6",
+        "next": "^15.5.19",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-icons": "^5.5.0",
@@ -1294,9 +1295,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.6.tgz",
-      "integrity": "sha512-3qBGRW+sCGzgbpc5TS1a0p7eNxnOarGVQhZxfvTdnV0gFI61lX7QNtQ4V1TSREctXzYn5NetbUsLvyqwLFJM6Q==",
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.19.tgz",
+      "integrity": "sha512-sWWluFvcv5v3Fxznmf2ZfjyoVQt/64oCnYqS90inQWGzMPK1VjvekPiz3OPHKmFT30EnHrjlbyaHLt3M0vWabw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1310,9 +1311,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.6.tgz",
-      "integrity": "sha512-ES3nRz7N+L5Umz4KoGfZ4XX6gwHplwPhioVRc25+QNsDa7RtUF/z8wJcbuQ2Tffm5RZwuN2A063eapoJ1u4nPg==",
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.19.tgz",
+      "integrity": "sha512-jx9wWlTKueHKPvVOndyr7WuaevWCkuYqsQ8gC0TMPKAVWG3MhcdMrjfo9tvIZNXd0QOUYXXvAcZ325y8Uq7uzg==",
       "cpu": [
         "arm64"
       ],
@@ -1326,9 +1327,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.6.tgz",
-      "integrity": "sha512-JIGcytAyk9LQp2/nuVZPAtj8uaJ/zZhsKOASTjxDug0SPU9LAM3wy6nPU735M1OqacR4U20LHVF5v5Wnl9ptTA==",
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.19.tgz",
+      "integrity": "sha512-291KFcsIQ3OenRdiUDFOR6W3wezzH4auENXm1gbm1Bjd4ANMMRgxPrWTUztQN43BnVoVuMnHCrLeECIMwgFKbA==",
       "cpu": [
         "x64"
       ],
@@ -1342,11 +1343,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.6.tgz",
-      "integrity": "sha512-qvz4SVKQ0P3/Im9zcS2RmfFL/UCQnsJKJwQSkissbngnB/12c6bZTCB0gHTexz1s6d/mD0+egPKXAIRFVS7hQg==",
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.19.tgz",
+      "integrity": "sha512-WeH+nelQyyMeE2f8FxBRZNrGipya5zHZV2vjzfCOAYyiI6am+NbnWAAldOBFQBB2w0DjJcsvrKqoFT2b7+5YoA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1358,11 +1362,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.6.tgz",
-      "integrity": "sha512-FsbGVw3SJz1hZlvnWD+T6GFgV9/NYDeLTNQB2MXoPN5u9VA9OEDy6fJEfePfsUKAhJufFbZLgp0cPxMuV6SV0w==",
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.19.tgz",
+      "integrity": "sha512-5xTOE0lDlDCSSfp+BAif7j17VRRCjWp//ZPZy6NI0QpdrhxtQnsZguSx0xAAZ0c9XZLrLLwCe/XVe5YPrRilKw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1374,11 +1381,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.6.tgz",
-      "integrity": "sha512-3QnHGFWlnvAgyxFxt2Ny8PTpXtQD7kVEeaFat5oPAHHI192WKYB+VIKZijtHLGdBBvc16tiAkPTDmQNOQ0dyrA==",
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.19.tgz",
+      "integrity": "sha512-LTxRmMgqqMv05Had879W00Fm53quiJd3Zuz8h1JSNJ3nGSlbZ/7Tjs1tKyScgN3Au3t3MyPsjPlq60fMmSHLsg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1390,11 +1400,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.6.tgz",
-      "integrity": "sha512-OsGX148sL+TqMK9YFaPFPoIaJKbFJJxFzkXZljIgA9hjMjdruKht6xDCEv1HLtlLNfkx3c5w2GLKhj7veBQizQ==",
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.19.tgz",
+      "integrity": "sha512-eoNQSpA5PQfB9wBO4RA47MTDXWz1fizy9Y3Z6e4DetYIF3dvjuu8sj7aIGn/bFCU6lnFzTK34NtCaffP4NsQ7Q==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1406,9 +1419,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.6.tgz",
-      "integrity": "sha512-ONOMrqWxdzXDJNh2n60H6gGyKed42Ieu6UTVPZteXpuKbLZTH4G4eBMsr5qWgOBA+s7F+uB4OJbZnrkEDnZ5Fg==",
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.19.tgz",
+      "integrity": "sha512-6UNt2dFuCHOe446sm/Kp69nUe8/wIhnh9bm6Xcqw4qEWCOppLMOvhTBVgvM7invVUNr4SPpP6NOQsACtn2IN9Q==",
       "cpu": [
         "arm64"
       ],
@@ -1422,9 +1435,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.6.tgz",
-      "integrity": "sha512-pxK4VIjFRx1MY92UycLOOw7dTdvccWsNETQ0kDHkBlcFH1GrTLUjSiHU1ohrznnux6TqRHgv5oflhfIWZwVROQ==",
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.19.tgz",
+      "integrity": "sha512-PhmojAHyqMne56HBLGu9dhDnHPuFmEjrXSQMM/nW0J6j849lk3ESrVtqNJcCk8CKOV7brpTTbaYAjwKPzKM69w==",
       "cpu": [
         "x64"
       ],
@@ -1643,6 +1656,90 @@
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.108.2.tgz",
+      "integrity": "sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.108.2.tgz",
+      "integrity": "sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.4.tgz",
+      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.108.2.tgz",
+      "integrity": "sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.108.2.tgz",
+      "integrity": "sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.2",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.108.2.tgz",
+      "integrity": "sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.108.2.tgz",
+      "integrity": "sha512-hFhnPveb5JQg4a0QYicM0swT253YHMdfeRAl2BKHOlI5VAzuHxUGSr8RbwNLYNPauWOgQMS1H8sz8bvYlgwUfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.108.2",
+        "@supabase/functions-js": "2.108.2",
+        "@supabase/postgrest-js": "2.108.2",
+        "@supabase/realtime-js": "2.108.2",
+        "@supabase/storage-js": "2.108.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -6666,6 +6763,15 @@
         "ms": "^2.0.0"
       }
     },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/iconv-corefoundation": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz",
@@ -8873,12 +8979,12 @@
       }
     },
     "node_modules/next": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.6.tgz",
-      "integrity": "sha512-zTxsnI3LQo3c9HSdSf91O1jMNsEzIXDShXd4wVdg9y5shwLqBXi4ZtUUJyB86KGVSJLZx0PFONvO54aheGX8QQ==",
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.19.tgz",
+      "integrity": "sha512-xNOW6tYshGX1/Oi3F8uuk4gpDeWsSUE/1Z0G5uUMekIxaQ0xc03UXd9II0VQHYMWviMeA0OHpJFAKsHf8bTYVg==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.6",
+        "@next/env": "15.5.19",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -8891,14 +8997,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.6",
-        "@next/swc-darwin-x64": "15.5.6",
-        "@next/swc-linux-arm64-gnu": "15.5.6",
-        "@next/swc-linux-arm64-musl": "15.5.6",
-        "@next/swc-linux-x64-gnu": "15.5.6",
-        "@next/swc-linux-x64-musl": "15.5.6",
-        "@next/swc-win32-arm64-msvc": "15.5.6",
-        "@next/swc-win32-x64-msvc": "15.5.6",
+        "@next/swc-darwin-arm64": "15.5.19",
+        "@next/swc-darwin-x64": "15.5.19",
+        "@next/swc-linux-arm64-gnu": "15.5.19",
+        "@next/swc-linux-arm64-musl": "15.5.19",
+        "@next/swc-linux-x64-gnu": "15.5.19",
+        "@next/swc-linux-x64-musl": "15.5.19",
+        "@next/swc-win32-arm64-msvc": "15.5.19",
+        "@next/swc-win32-x64-msvc": "15.5.19",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,11 +30,12 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.68",
     "@prisma/client": "^6.1.0",
+    "@supabase/supabase-js": "^2.108.2",
     "dotenv": "^16.4.5",
     "framer-motion": "^11.11.17",
     "highlight.js": "^11.10.0",
     "lucide-react": "^0.460.0",
-    "next": "^15.5.6",
+    "next": "^15.5.19",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-icons": "^5.5.0",

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile.frontend"
+  },
+  "deploy": {
+    "healthcheckPath": "/cloud/login",
+    "healthcheckTimeout": 120,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 5
+  }
+}

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.env
+*.log
+npm-debug.log*
+.DS_Store

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,34 @@
+# ── Claudable Cloud — backend env ───────────────────────────────────────────
+# Copy to server/.env and fill in. NEVER commit real secrets.
+
+NODE_ENV=development
+PORT=8080
+
+# ── Supabase ────────────────────────────────────────────────────────────────
+SUPABASE_URL=https://YOUR-PROJECT.supabase.co
+# Server-only. Full DB access, bypasses RLS. Keep secret.
+SUPABASE_SERVICE_ROLE_KEY=
+# Used to verify user JWTs.
+SUPABASE_ANON_KEY=
+SUPABASE_STORAGE_BUCKET=project-artifacts
+
+# ── Claude Code (injected into workspace containers) ────────────────────────
+ANTHROPIC_API_KEY=
+CLAUDE_DEFAULT_MODEL=claude-sonnet-4-6
+
+# ── Workspace containers ────────────────────────────────────────────────────
+WORKSPACE_IMAGE=claudable-workspace:latest
+MAX_CONCURRENT_WORKSPACES=10
+WORKSPACE_IDLE_TTL_MS=900000
+WORKSPACE_REAPER_INTERVAL_MS=60000
+WORKSPACE_CPU_LIMIT=1
+WORKSPACE_MEMORY_LIMIT_MB=2048
+EXECUTION_TIMEOUT_MS=1200000
+# Host path for project workspaces (bind-mounted into workspace containers).
+WORKSPACES_ROOT=/var/lib/claudable/workspaces
+
+# ── Frontend / flags ────────────────────────────────────────────────────────
+FRONTEND_ORIGIN=http://localhost:3000
+ENABLE_GOOGLE_OAUTH=0
+# Set to 1 to run without a Docker daemon (NullWorkspaceDriver; no real execution).
+DISABLE_DOCKER=0

--- a/server/.railwayignore
+++ b/server/.railwayignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+*.log

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,51 @@
+# Claudable Cloud — orchestration backend image.
+#
+# Supports two execution modes (WORKSPACE_MODE):
+#   docker  — manages sibling workspace containers via the host Docker socket
+#             (mounted at runtime via docker-compose on a VM).
+#   process — runs Claude Code as a subprocess in THIS container (Railway/Render),
+#             dropping each child to the non-root `coder` user. This image bundles
+#             Claude Code + git + build tools so that mode works out of the box.
+FROM node:22-bookworm-slim AS build
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+FROM node:22-bookworm-slim AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+
+# Tooling needed when WORKSPACE_MODE=process: git + native build deps + tini.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+       git ca-certificates curl python3 build-essential tini \
+  && rm -rf /var/lib/apt/lists/*
+
+# Claude Code + package managers, available on PATH for spawned children.
+ARG CLAUDE_CODE_VERSION=latest
+RUN corepack enable \
+  && npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
+  && npm cache clean --force
+
+# Claude Code child processes run as the base image's existing non-root `node`
+# user (uid/gid 1000, home /home/node) — Claude Code refuses to run as root.
+
+# Backend production deps.
+COPY package.json ./
+RUN npm install --omit=dev && npm cache clean --force
+COPY --from=build /app/dist ./dist
+
+# Defaults for PaaS (Railway): in-process execution, workspaces on a mounted volume.
+ENV WORKSPACE_MODE=process \
+    WORKSPACES_ROOT=/data/workspaces \
+    WORKSPACE_RUN_HOME=/home/node \
+    PORT=8080
+
+# The backend runs as root so it can chown workspace dirs and drop privileges for
+# child Claude Code processes. Children never run as root.
+EXPOSE 8080
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["node", "dist/index.js"]

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,0 +1,3768 @@
+{
+  "name": "claudable-cloud-server",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "claudable-cloud-server",
+      "version": "0.1.0",
+      "dependencies": {
+        "@supabase/supabase-js": "^2.45.0",
+        "dockerode": "^4.0.2",
+        "dotenv": "^16.4.5",
+        "express": "^4.21.0",
+        "pino": "^9.5.0",
+        "pino-http": "^10.3.0",
+        "tar-fs": "^3.0.6",
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "devDependencies": {
+        "@types/dockerode": "^3.3.31",
+        "@types/express": "^4.17.21",
+        "@types/node": "^22.10.0",
+        "@types/tar-fs": "^2.0.4",
+        "@types/ws": "^8.5.13",
+        "eslint": "^9.17.0",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.108.2.tgz",
+      "integrity": "sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.108.2.tgz",
+      "integrity": "sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.4.tgz",
+      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.108.2.tgz",
+      "integrity": "sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.108.2.tgz",
+      "integrity": "sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.2",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.108.2.tgz",
+      "integrity": "sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.108.2.tgz",
+      "integrity": "sha512-hFhnPveb5JQg4a0QYicM0swT253YHMdfeRAl2BKHOlI5VAzuHxUGSr8RbwNLYNPauWOgQMS1H8sz8bvYlgwUfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.108.2",
+        "@supabase/functions-js": "2.108.2",
+        "@supabase/postgrest-js": "2.108.2",
+        "@supabase/realtime-js": "2.108.2",
+        "@supabase/storage-js": "2.108.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/docker-modem": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
+      "integrity": "sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
+    "node_modules/@types/dockerode": {
+      "version": "3.3.47",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.47.tgz",
+      "integrity": "sha512-ShM1mz7rCjdssXt7Xz0u1/R2BJC7piWa3SJpUBiVjCf2A3XNn4cP6pUVaD8bLanpPVVn4IKzJuw3dOvkJ8IbYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/docker-modem": "*",
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tar-fs": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/tar-fs/-/tar-fs-2.0.4.tgz",
+      "integrity": "sha512-ipPec0CjTmVDWE+QKr9cTmIIoTl7dFG/yARCM5MqK8i6CNLIG1P8x4kwDsOQY1ChZOZjH0wO9nvfgBvWl4R3kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tar-stream": "*"
+      }
+    },
+    "node_modules/@types/tar-stream": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/tar-stream/-/tar-stream-3.1.4.tgz",
+      "integrity": "sha512-921gW0+g29mCJX0fRvqeHzBlE/XclDaAG0Ousy1LCghsOhvaKacDeRGEVzQP9IPfKn8Vysy7FEXAIxycpc/CMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.3.tgz",
+      "integrity": "sha512-fF4Q7QsyKVF5Rj0qvI8BgUNjqzC2JvQlpTaPLjVJVxYVUX5Zr9un+y3w1HmA4nNKdFmRBT8z/WmrjvXzXVerKQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/docker-modem": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.7.tgz",
+      "integrity": "sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "readable-stream": "^3.5.0",
+        "split-ca": "^1.0.1",
+        "ssh2": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/dockerode": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.12.tgz",
+      "integrity": "sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2",
+        "@grpc/grpc-js": "^1.11.1",
+        "@grpc/proto-loader": "^0.7.13",
+        "docker-modem": "^5.0.7",
+        "protobufjs": "^7.3.2",
+        "tar-fs": "^2.1.4",
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/dockerode/node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/dockerode/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nan": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-http": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-10.5.0.tgz",
+      "integrity": "sha512-hD91XjgaKkSsdn8P7LaebrNzhGTdB086W3pyPihX0EzGPjq5uBJBXo4N5guqNaK6mUjg9aubMF7wDViYek9dRA==",
+      "license": "MIT",
+      "dependencies": {
+        "get-caller-file": "^2.0.5",
+        "pino": "^9.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/split-ca": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
+      "license": "ISC"
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/ssh2": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
+      "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "claudable-cloud-server",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Orchestration backend for Claudable Cloud — manages Claude Code workspace containers",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint src --ext .ts"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.45.0",
+    "dockerode": "^4.0.2",
+    "dotenv": "^16.4.5",
+    "express": "^4.21.0",
+    "pino": "^9.5.0",
+    "pino-http": "^10.3.0",
+    "tar-fs": "^3.0.6",
+    "ws": "^8.18.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/dockerode": "^3.3.31",
+    "@types/express": "^4.17.21",
+    "@types/node": "^22.10.0",
+    "@types/tar-fs": "^2.0.4",
+    "@types/ws": "^8.5.13",
+    "eslint": "^9.17.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/server/railway.json
+++ b/server/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "startCommand": "node dist/index.js",
+    "healthcheckPath": "/healthz",
+    "healthcheckTimeout": 120,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 5
+  }
+}

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,0 +1,38 @@
+/**
+ * Express application factory. Kept separate from index.ts so it can be
+ * imported in tests without binding a port.
+ */
+import express, { type Express } from 'express';
+import { pinoHttp } from 'pino-http';
+import { env } from './config/env';
+import { logger } from './lib/logger';
+import { errorMiddleware } from './lib/errors';
+import { healthRouter } from './routes/health';
+import { projectsRouter } from './routes/projects';
+import { settingsRouter } from './routes/settings';
+
+export function createApp(): Express {
+  const app = express();
+
+  app.use(pinoHttp({ logger }));
+  app.use(express.json({ limit: '10mb' }));
+
+  // CORS for the Next.js frontend.
+  app.use((req, res, next) => {
+    res.header('Access-Control-Allow-Origin', env.FRONTEND_ORIGIN);
+    res.header('Access-Control-Allow-Headers', 'Authorization, Content-Type');
+    res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+    if (req.method === 'OPTIONS') {
+      res.sendStatus(204);
+      return;
+    }
+    next();
+  });
+
+  app.use(healthRouter);
+  app.use('/api/projects', projectsRouter);
+  app.use('/api/settings', settingsRouter);
+
+  app.use(errorMiddleware);
+  return app;
+}

--- a/server/src/claude/normalize.ts
+++ b/server/src/claude/normalize.ts
@@ -1,0 +1,95 @@
+/**
+ * Normalizes Claude Code tool calls into the app's common action vocabulary.
+ * Condensed port of lib/services/cli/claude.ts from the desktop codebase.
+ */
+import type { ToolAction } from '../realtime/events';
+
+const TOOL_NAME_ACTION_MAP: Record<string, ToolAction> = {
+  read: 'Read',
+  read_file: 'Read',
+  write: 'Created',
+  write_file: 'Created',
+  create_file: 'Created',
+  edit: 'Edited',
+  edit_file: 'Edited',
+  multiedit: 'Edited',
+  update_file: 'Edited',
+  apply_patch: 'Edited',
+  notebookedit: 'Edited',
+  delete_file: 'Deleted',
+  remove_file: 'Deleted',
+  ls: 'Searched',
+  glob: 'Searched',
+  grep: 'Searched',
+  search_files: 'Searched',
+  bash: 'Executed',
+  run: 'Executed',
+  shell: 'Executed',
+  todowrite: 'Generated',
+  task: 'Generated',
+  webfetch: 'Read',
+  websearch: 'Searched',
+};
+
+function fromKeyword(value: string): ToolAction | undefined {
+  const c = value.toLowerCase();
+  if (/(edit|modify|update|patch)/.test(c)) return 'Edited';
+  if (/(write|create|add|append)/.test(c)) return 'Created';
+  if (/(read|open|view|fetch)/.test(c)) return 'Read';
+  if (/(delete|remove)/.test(c)) return 'Deleted';
+  if (/(search|find|list|glob|grep|ls)/.test(c)) return 'Searched';
+  if (/(generate|todo|plan|task)/.test(c)) return 'Generated';
+  if (/(execute|exec|run|bash|shell|command)/.test(c)) return 'Executed';
+  return undefined;
+}
+
+export function inferAction(toolName: string): ToolAction | undefined {
+  const normalized = toolName.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (TOOL_NAME_ACTION_MAP[normalized]) return TOOL_NAME_ACTION_MAP[normalized];
+  const suffix = normalized.split(/[:_-]/).pop() ?? normalized;
+  return TOOL_NAME_ACTION_MAP[suffix] ?? fromKeyword(normalized);
+}
+
+const PATH_KEYS = [
+  'file_path',
+  'filePath',
+  'path',
+  'notebook_path',
+  'target',
+  'pattern',
+  'directory',
+];
+
+/** Pull a representative file path or command out of a tool's input object. */
+export function extractTarget(
+  toolName: string,
+  input: unknown,
+): { filePath?: string; command?: string } {
+  if (!input || typeof input !== 'object') return {};
+  const rec = input as Record<string, unknown>;
+
+  for (const key of PATH_KEYS) {
+    const v = rec[key];
+    if (typeof v === 'string' && v.trim()) return { filePath: v.trim() };
+  }
+
+  const cmd = rec.command ?? rec.cmd;
+  if (typeof cmd === 'string' && cmd.trim()) {
+    return { command: cmd.trim() };
+  }
+  return {};
+}
+
+/** Build the metadata blob persisted alongside a tool message. */
+export function buildToolMetadata(toolName: string, input: unknown) {
+  const action = inferAction(toolName);
+  const { filePath, command } = extractTarget(toolName, input);
+  return {
+    toolName,
+    action,
+    ...(filePath ? { filePath } : {}),
+    ...(command ? { command } : {}),
+    toolInput: input,
+  };
+}

--- a/server/src/claude/runner.ts
+++ b/server/src/claude/runner.ts
@@ -1,0 +1,235 @@
+/**
+ * ClaudeRunner — drives headless Claude Code inside a workspace container and
+ * streams its full agentic output to the project's event bus.
+ *
+ * Claude Code is invoked non-interactively with `--output-format stream-json`,
+ * which emits one JSON object per line: a system/init line (carrying the
+ * session_id we persist for resumption), assistant lines (text + tool_use
+ * blocks), user lines (tool_result blocks), and a final result line.
+ */
+import { randomUUID } from 'node:crypto';
+import { env, operatorCredentialEnv } from '../config/env';
+import { getAnthropicKey } from '../services/user-settings';
+import { projectLogger } from '../lib/logger';
+import { eventBus } from '../realtime/event-bus';
+import { makeEvent } from '../realtime/events';
+import { appendMessage } from '../services/chat';
+import { getProject, updateProject, setProjectStatus, touchProject } from '../services/projects';
+import { sessionManager } from '../workspace/session-manager';
+import { buildToolMetadata } from './normalize';
+
+export interface RunOptions {
+  projectId: string;
+  prompt: string;
+  model?: string;
+  /** when true, do not resume a prior session (first prompt of a project) */
+  isInitial?: boolean;
+  requestId?: string;
+}
+
+interface ClaudeStreamLine {
+  type: string;
+  subtype?: string;
+  session_id?: string;
+  message?: {
+    content?: Array<Record<string, unknown>>;
+  };
+  result?: string;
+  duration_ms?: number;
+  is_error?: boolean;
+  total_cost_usd?: number;
+}
+
+/**
+ * Execute one turn. Persists messages, publishes realtime events, captures the
+ * Claude session id for resumption, and returns when the run completes.
+ */
+export async function runClaude(opts: RunOptions): Promise<{ ok: boolean; error?: string }> {
+  const { projectId } = opts;
+  const requestId = opts.requestId ?? randomUUID();
+  const log = projectLogger(projectId);
+  const startedAt = Date.now();
+
+  const publish = (type: string, data: unknown) =>
+    eventBus.publish(makeEvent(type, projectId, data, { requestId }));
+
+  const project = await getProject(projectId);
+  if (!project) {
+    return { ok: false, error: 'Project not found' };
+  }
+
+  const model = opts.model ?? project.selected_model ?? env.CLAUDE_DEFAULT_MODEL;
+  const resumeSessionId = opts.isInitial ? undefined : project.claude_session_id ?? undefined;
+
+  // Resolve the Claude credential (BYOK): the project owner's key, else the
+  // operator fallback. Bail early — before spinning up a workspace — if neither.
+  const userKey = await getAnthropicKey(project.user_id);
+  const credentialEnv = userKey ? { ANTHROPIC_API_KEY: userKey } : operatorCredentialEnv();
+  if (!credentialEnv.ANTHROPIC_API_KEY && !credentialEnv.CLAUDE_CODE_OAUTH_TOKEN) {
+    const message = 'No Anthropic API key configured. Add your key in Settings to run Claude Code.';
+    publish('completion', { ok: false, error: message });
+    await appendMessage({ projectId, role: 'system', message, requestId }).catch(() => {});
+    await setProjectStatus(projectId, 'idle').catch(() => {});
+    return { ok: false, error: message };
+  }
+
+  // Ensure a running workspace and mark it busy so the reaper leaves it alone.
+  const workspace = await sessionManager.getOrStartWorkspace(projectId);
+  sessionManager.markExecuting(projectId, true);
+  await setProjectStatus(projectId, 'executing');
+  publish('status', { status: 'executing', detail: 'Launching Claude Code' });
+
+  // Build the headless Claude Code command. Runs inside the sandboxed container,
+  // so we skip interactive permission prompts for autonomous operation.
+  const cmd = [
+    'claude',
+    '-p',
+    opts.prompt,
+    '--output-format',
+    'stream-json',
+    '--verbose',
+    '--dangerously-skip-permissions',
+    '--model',
+    model,
+  ];
+  if (resumeSessionId) {
+    cmd.push('--resume', resumeSessionId);
+  }
+
+  const abort = new AbortController();
+  const timeout = setTimeout(() => abort.abort(), env.EXECUTION_TIMEOUT_MS);
+
+  let capturedSessionId: string | undefined;
+  let buffer = '';
+
+  const handleLine = async (raw: string) => {
+    const line = raw.trim();
+    if (!line) return;
+    let evt: ClaudeStreamLine;
+    try {
+      evt = JSON.parse(line);
+    } catch {
+      // Non-JSON output (rare) — forward as a terminal line.
+      publish('terminal', { stream: 'stdout', line });
+      return;
+    }
+    await dispatchEvent(evt);
+  };
+
+  const dispatchEvent = async (evt: ClaudeStreamLine) => {
+    switch (evt.type) {
+      case 'system': {
+        if (evt.subtype === 'init' && evt.session_id) {
+          capturedSessionId = evt.session_id;
+        }
+        return;
+      }
+      case 'assistant': {
+        for (const block of evt.message?.content ?? []) {
+          const blockType = block.type as string;
+          if (blockType === 'text' && typeof block.text === 'string' && block.text.trim()) {
+            publish('message', { role: 'assistant', content: block.text });
+            await appendMessage({
+              projectId,
+              role: 'assistant',
+              message: block.text,
+              requestId,
+            });
+          } else if (blockType === 'tool_use') {
+            const toolName = String(block.name ?? 'tool');
+            const metadata = buildToolMetadata(toolName, block.input);
+            publish('tool', {
+              toolName,
+              action: metadata.action,
+              filePath: metadata.filePath,
+              command: metadata.command,
+              phase: 'start',
+            });
+            await appendMessage({
+              projectId,
+              role: 'tool',
+              message: metadata.filePath ?? metadata.command ?? toolName,
+              metadata,
+              requestId,
+            });
+          }
+        }
+        return;
+      }
+      case 'user': {
+        // tool_result blocks — surface as terminal/result output.
+        for (const block of evt.message?.content ?? []) {
+          if (block.type === 'tool_result') {
+            const content =
+              typeof block.content === 'string'
+                ? block.content
+                : JSON.stringify(block.content ?? '');
+            if (content) {
+              publish('tool', { toolName: 'result', phase: 'result', output: content.slice(0, 8000) });
+            }
+          }
+        }
+        return;
+      }
+      case 'result': {
+        if (typeof evt.result === 'string' && evt.result.trim()) {
+          publish('message', { role: 'assistant', content: evt.result });
+        }
+        return;
+      }
+      default:
+        return;
+    }
+  };
+
+  try {
+    const result = await sessionManager.getDriver().exec(workspace.containerId, {
+      cmd,
+      env: credentialEnv,
+      signal: abort.signal,
+      onStdout: (chunk) => {
+        buffer += chunk.toString('utf8');
+        let idx: number;
+        while ((idx = buffer.indexOf('\n')) >= 0) {
+          const line = buffer.slice(0, idx);
+          buffer = buffer.slice(idx + 1);
+          void handleLine(line);
+        }
+      },
+      onStderr: (chunk) => {
+        publish('terminal', { stream: 'stderr', line: chunk.toString('utf8') });
+      },
+    });
+
+    if (buffer.trim()) await handleLine(buffer);
+
+    // Persist the captured session id for the next turn's --resume.
+    if (capturedSessionId && capturedSessionId !== project.claude_session_id) {
+      await updateProject(projectId, { claude_session_id: capturedSessionId });
+    }
+
+    const ok = result.exitCode === 0;
+    const durationMs = Date.now() - startedAt;
+    publish('completion', { ok, durationMs, ...(ok ? {} : { error: `exit ${result.exitCode}` }) });
+    log.info({ ok, durationMs, exitCode: result.exitCode }, 'Claude run finished');
+    return ok ? { ok } : { ok, error: `Claude Code exited with code ${result.exitCode}` };
+  } catch (err) {
+    const aborted = abort.signal.aborted;
+    const message = aborted
+      ? `Execution timed out after ${env.EXECUTION_TIMEOUT_MS}ms`
+      : err instanceof Error
+        ? err.message
+        : String(err);
+    log.error({ err, aborted }, 'Claude run failed');
+    publish('completion', { ok: false, error: message });
+    await appendMessage({ projectId, role: 'system', message: `Error: ${message}`, requestId }).catch(
+      () => {},
+    );
+    return { ok: false, error: message };
+  } finally {
+    clearTimeout(timeout);
+    sessionManager.markExecuting(projectId, false);
+    await setProjectStatus(projectId, 'running').catch(() => {});
+    await touchProject(projectId).catch(() => {});
+  }
+}

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -1,0 +1,102 @@
+/**
+ * Centralized, validated environment configuration.
+ *
+ * Loaded once at process start. Any missing/invalid required variable
+ * fails fast with a readable error rather than surfacing deep in a request.
+ */
+import 'dotenv/config';
+import { z } from 'zod';
+
+const booleanish = z
+  .string()
+  .optional()
+  .transform((v) => v === '1' || v?.toLowerCase() === 'true');
+
+const schema = z.object({
+  NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
+  PORT: z.coerce.number().int().positive().default(8080),
+
+  // --- Supabase ---
+  SUPABASE_URL: z.string().url(),
+  // service-role key: server only, full DB access. NEVER expose to the browser.
+  SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
+  // anon key: only used to verify user JWTs / build user-scoped clients.
+  SUPABASE_ANON_KEY: z.string().min(1),
+  SUPABASE_STORAGE_BUCKET: z.string().default('project-artifacts'),
+
+  // --- Claude Code credential ---
+  // BYOK model: each user supplies their own Anthropic API key (stored
+  // encrypted, injected per workspace). These optional operator-level values
+  // act only as a fallback when a user has not set their own key.
+  ANTHROPIC_API_KEY: z.string().optional(),
+  CLAUDE_CODE_OAUTH_TOKEN: z.string().optional(),
+  CLAUDE_DEFAULT_MODEL: z.string().default('claude-sonnet-4-6'),
+
+  // 32-byte key (64 hex chars) for AES-256-GCM encryption of stored user secrets.
+  ENCRYPTION_KEY: z.string().regex(/^[0-9a-fA-F]{64}$/, 'ENCRYPTION_KEY must be 64 hex chars (32 bytes)'),
+
+  // --- Workspace containers ---
+  WORKSPACE_IMAGE: z.string().default('claudable-workspace:latest'),
+  // Max concurrent running containers before new work is queued.
+  MAX_CONCURRENT_WORKSPACES: z.coerce.number().int().positive().default(10),
+  // Idle TTL (ms) after which a container is archived + stopped by the reaper.
+  WORKSPACE_IDLE_TTL_MS: z.coerce.number().int().positive().default(15 * 60 * 1000),
+  WORKSPACE_REAPER_INTERVAL_MS: z.coerce.number().int().positive().default(60 * 1000),
+  // Per-container resource caps.
+  WORKSPACE_CPU_LIMIT: z.coerce.number().positive().default(1),
+  WORKSPACE_MEMORY_LIMIT_MB: z.coerce.number().int().positive().default(2048),
+  // Hard cap on a single Claude Code execution (ms).
+  EXECUTION_TIMEOUT_MS: z.coerce.number().int().positive().default(20 * 60 * 1000),
+
+  // Host-side root for project workspaces that are bind-mounted into containers.
+  WORKSPACES_ROOT: z.string().default('/var/lib/claudable/workspaces'),
+
+  // Execution backend: 'docker' = one container per project (needs host Docker
+  // daemon); 'process' = Claude Code as a subprocess in this container (works on
+  // PaaS like Railway/Render that don't expose the Docker socket).
+  WORKSPACE_MODE: z.enum(['docker', 'process']).default('docker'),
+  // When WORKSPACE_MODE=process and this server runs as root, Claude Code child
+  // processes are dropped to this uid/gid (Claude Code refuses
+  // --dangerously-skip-permissions as root). HOME must be writable by that uid.
+  WORKSPACE_RUN_UID: z.coerce.number().int().nonnegative().default(1000),
+  WORKSPACE_RUN_GID: z.coerce.number().int().nonnegative().default(1000),
+  WORKSPACE_RUN_HOME: z.string().default('/home/coder'),
+
+  // --- CORS / frontend ---
+  FRONTEND_ORIGIN: z.string().default('*'),
+
+  // --- Feature flags ---
+  ENABLE_GOOGLE_OAUTH: booleanish,
+  // Disable Docker (useful for local dev / CI where no daemon is present).
+  DISABLE_DOCKER: booleanish,
+});
+
+export type AppEnv = z.infer<typeof schema>;
+
+/**
+ * Operator-level fallback credential, used only when a user hasn't supplied
+ * their own key (BYOK). Empty object = no fallback configured.
+ */
+export function operatorCredentialEnv(): Record<string, string> {
+  if (env.CLAUDE_CODE_OAUTH_TOKEN) return { CLAUDE_CODE_OAUTH_TOKEN: env.CLAUDE_CODE_OAUTH_TOKEN };
+  if (env.ANTHROPIC_API_KEY) return { ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY };
+  return {};
+}
+
+function loadEnv(): AppEnv {
+  const parsed = schema.safeParse(process.env);
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((i) => `  - ${i.path.join('.') || '(root)'}: ${i.message}`)
+      .join('\n');
+    // eslint-disable-next-line no-console
+    console.error(`\n❌ Invalid environment configuration:\n${issues}\n`);
+    process.exit(1);
+  }
+  return parsed.data;
+}
+
+export const env: AppEnv = loadEnv();
+
+export const isProd = env.NODE_ENV === 'production';
+export const isDev = env.NODE_ENV === 'development';

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Server entry point.
+ * Boots the session manager (Docker reconciliation + reaper), starts the HTTP
+ * server, and attaches the WebSocket server to the same port.
+ */
+import { createServer } from 'node:http';
+import { env } from './config/env';
+import { logger } from './lib/logger';
+import { createApp } from './app';
+import { attachWebSocketServer } from './realtime/ws-server';
+import { sessionManager } from './workspace/session-manager';
+
+async function main() {
+  // Initialize workspace orchestration before accepting traffic.
+  await sessionManager.init().catch((err) => {
+    logger.error({ err }, 'Session manager init failed (continuing without containers)');
+  });
+
+  const app = createApp();
+  const server = createServer(app);
+  attachWebSocketServer(server);
+
+  server.listen(env.PORT, () => {
+    logger.info({ port: env.PORT }, '🚀 Claudable Cloud server listening');
+  });
+
+  const shutdown = async (signal: string) => {
+    logger.info({ signal }, 'Shutting down');
+    await sessionManager.shutdown().catch(() => {});
+    server.close(() => process.exit(0));
+    // Force-exit if connections linger.
+    setTimeout(() => process.exit(0), 10_000).unref();
+  };
+  process.on('SIGTERM', () => void shutdown('SIGTERM'));
+  process.on('SIGINT', () => void shutdown('SIGINT'));
+}
+
+main().catch((err) => {
+  logger.error({ err }, 'Fatal startup error');
+  process.exit(1);
+});

--- a/server/src/lib/crypto.ts
+++ b/server/src/lib/crypto.ts
@@ -1,0 +1,36 @@
+/**
+ * Application-layer encryption for user secrets (BYOK Anthropic keys).
+ * AES-256-GCM with a server-side ENCRYPTION_KEY (32 bytes / 64 hex chars).
+ * Stored format: base64(iv):base64(authTag):base64(ciphertext).
+ */
+import crypto from 'node:crypto';
+import { env } from '../config/env';
+
+const ALGO = 'aes-256-gcm';
+const KEY = Buffer.from(env.ENCRYPTION_KEY, 'hex');
+
+export function encryptSecret(plaintext: string): string {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv(ALGO, KEY, iv);
+  const enc = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return [iv.toString('base64'), tag.toString('base64'), enc.toString('base64')].join(':');
+}
+
+export function decryptSecret(payload: string): string {
+  const [ivB64, tagB64, dataB64] = payload.split(':');
+  if (!ivB64 || !tagB64 || !dataB64) {
+    throw new Error('Malformed encrypted payload');
+  }
+  const decipher = crypto.createDecipheriv(ALGO, KEY, Buffer.from(ivB64, 'base64'));
+  decipher.setAuthTag(Buffer.from(tagB64, 'base64'));
+  return Buffer.concat([decipher.update(Buffer.from(dataB64, 'base64')), decipher.final()]).toString(
+    'utf8',
+  );
+}
+
+/** Masked preview for UI confirmation, e.g. "sk-ant-…powQ". Never returns the full key. */
+export function maskKey(raw: string): string {
+  if (raw.length <= 10) return '••••';
+  return `${raw.slice(0, 6)}…${raw.slice(-4)}`;
+}

--- a/server/src/lib/errors.ts
+++ b/server/src/lib/errors.ts
@@ -1,0 +1,69 @@
+/**
+ * Typed application errors + an Express error-handling middleware.
+ * Routes throw AppError (or call the http helpers); the middleware turns
+ * them into clean JSON responses and logs the rest.
+ */
+import type { NextFunction, Request, Response } from 'express';
+import { ZodError } from 'zod';
+import { logger } from './logger';
+import { isProd } from '../config/env';
+
+export class AppError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    message: string,
+    public readonly code: string = 'app_error',
+    public readonly details?: unknown,
+  ) {
+    super(message);
+    this.name = 'AppError';
+  }
+}
+
+export const httpErrors = {
+  badRequest: (msg = 'Bad request', details?: unknown) =>
+    new AppError(400, msg, 'bad_request', details),
+  unauthorized: (msg = 'Unauthorized') => new AppError(401, msg, 'unauthorized'),
+  forbidden: (msg = 'Forbidden') => new AppError(403, msg, 'forbidden'),
+  notFound: (msg = 'Not found') => new AppError(404, msg, 'not_found'),
+  conflict: (msg = 'Conflict') => new AppError(409, msg, 'conflict'),
+  tooManyRequests: (msg = 'Too many requests') =>
+    new AppError(429, msg, 'rate_limited'),
+  internal: (msg = 'Internal server error') => new AppError(500, msg, 'internal'),
+};
+
+/** Wrap an async route handler so thrown errors reach the error middleware. */
+export function asyncHandler<T extends (req: Request, res: Response, next: NextFunction) => unknown>(
+  fn: T,
+) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function errorMiddleware(err: unknown, _req: Request, res: Response, _next: NextFunction) {
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      error: { code: 'validation_error', message: 'Invalid request', details: err.issues },
+    });
+  }
+
+  if (err instanceof AppError) {
+    if (err.statusCode >= 500) {
+      logger.error({ err }, 'Unhandled application error');
+    }
+    return res.status(err.statusCode).json({
+      error: { code: err.code, message: err.message, details: err.details },
+    });
+  }
+
+  logger.error({ err }, 'Unexpected error');
+  return res.status(500).json({
+    error: {
+      code: 'internal',
+      message: 'Internal server error',
+      ...(isProd ? {} : { details: err instanceof Error ? err.message : String(err) }),
+    },
+  });
+}

--- a/server/src/lib/logger.ts
+++ b/server/src/lib/logger.ts
@@ -1,0 +1,31 @@
+/**
+ * Structured logger (pino). Secrets are redacted globally so tokens/keys
+ * never leak into logs even if accidentally attached to a log object.
+ */
+import { pino } from 'pino';
+import { env, isDev } from '../config/env';
+
+export const logger = pino({
+  level: process.env.LOG_LEVEL ?? (isDev ? 'debug' : 'info'),
+  redact: {
+    paths: [
+      'req.headers.authorization',
+      'req.headers.cookie',
+      '*.ANTHROPIC_API_KEY',
+      '*.SUPABASE_SERVICE_ROLE_KEY',
+      '*.token',
+      '*.apiKey',
+      '*.password',
+    ],
+    censor: '[redacted]',
+  },
+  transport: isDev
+    ? { target: 'pino-pretty', options: { colorize: true, translateTime: 'SYS:HH:MM:ss' } }
+    : undefined,
+  base: { service: 'claudable-cloud-server', env: env.NODE_ENV },
+});
+
+/** Create a child logger scoped to a project (and optionally a container). */
+export function projectLogger(projectId: string, containerId?: string) {
+  return logger.child({ projectId, ...(containerId ? { containerId } : {}) });
+}

--- a/server/src/lib/supabase.ts
+++ b/server/src/lib/supabase.ts
@@ -1,0 +1,33 @@
+/**
+ * Supabase clients.
+ *
+ * - `admin`: service-role client. Bypasses RLS — use ONLY on the server, and
+ *   always enforce ownership in application code (see services/projects.ts).
+ * - `verifyAccessToken`: validates a user's JWT (from the Authorization header)
+ *   and returns the authenticated user.
+ */
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { env } from '../config/env';
+
+export const admin: SupabaseClient = createClient(
+  env.SUPABASE_URL,
+  env.SUPABASE_SERVICE_ROLE_KEY,
+  { auth: { autoRefreshToken: false, persistSession: false } },
+);
+
+export interface AuthedUser {
+  id: string;
+  email: string | null;
+}
+
+/**
+ * Verify a bearer access token issued by Supabase Auth.
+ * Returns the user, or null if the token is missing/invalid/expired.
+ */
+export async function verifyAccessToken(accessToken: string): Promise<AuthedUser | null> {
+  const { data, error } = await admin.auth.getUser(accessToken);
+  if (error || !data.user) {
+    return null;
+  }
+  return { id: data.user.id, email: data.user.email ?? null };
+}

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,0 +1,53 @@
+/**
+ * Authentication middleware.
+ * Extracts the Supabase access token from the Authorization header,
+ * verifies it, and attaches the authenticated user to the request.
+ */
+import type { NextFunction, Request, Response } from 'express';
+import { httpErrors } from '../lib/errors';
+import { verifyAccessToken, type AuthedUser } from '../lib/supabase';
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      user?: AuthedUser;
+    }
+  }
+}
+
+function extractBearer(req: Request): string | null {
+  const header = req.headers.authorization;
+  if (header && header.startsWith('Bearer ')) {
+    return header.slice('Bearer '.length).trim() || null;
+  }
+  // WebSocket upgrade requests can pass the token as a query param.
+  const queryToken = req.query.access_token;
+  if (typeof queryToken === 'string' && queryToken.length > 0) {
+    return queryToken;
+  }
+  return null;
+}
+
+export async function requireAuth(req: Request, _res: Response, next: NextFunction) {
+  try {
+    const token = extractBearer(req);
+    if (!token) {
+      throw httpErrors.unauthorized('Missing access token');
+    }
+    const user = await verifyAccessToken(token);
+    if (!user) {
+      throw httpErrors.unauthorized('Invalid or expired access token');
+    }
+    req.user = user;
+    next();
+  } catch (err) {
+    next(err);
+  }
+}
+
+/** Resolve and verify a user from a raw token (used by the WebSocket upgrade path). */
+export async function authenticateToken(token: string | null): Promise<AuthedUser | null> {
+  if (!token) return null;
+  return verifyAccessToken(token);
+}

--- a/server/src/realtime/event-bus.ts
+++ b/server/src/realtime/event-bus.ts
@@ -1,0 +1,53 @@
+/**
+ * EventBus — per-project publish/subscribe for realtime events.
+ *
+ * The Claude runner publishes once; every subscribed transport (WebSocket
+ * connections AND SSE responses) receives the event. Stored as a globalThis
+ * singleton so hot-reload / multiple imports share one instance.
+ */
+import type { RealtimeEnvelope } from './events';
+import { logger } from '../lib/logger';
+
+type Subscriber = (event: RealtimeEnvelope) => void;
+
+class EventBus {
+  private subscribers = new Map<string, Set<Subscriber>>();
+
+  subscribe(projectId: string, fn: Subscriber): () => void {
+    let set = this.subscribers.get(projectId);
+    if (!set) {
+      set = new Set();
+      this.subscribers.set(projectId, set);
+    }
+    set.add(fn);
+    return () => this.unsubscribe(projectId, fn);
+  }
+
+  private unsubscribe(projectId: string, fn: Subscriber): void {
+    const set = this.subscribers.get(projectId);
+    if (!set) return;
+    set.delete(fn);
+    if (set.size === 0) {
+      this.subscribers.delete(projectId);
+    }
+  }
+
+  publish(event: RealtimeEnvelope): void {
+    const set = this.subscribers.get(event.projectId);
+    if (!set || set.size === 0) return;
+    for (const fn of [...set]) {
+      try {
+        fn(event);
+      } catch (err) {
+        logger.warn({ err, projectId: event.projectId }, 'EventBus subscriber threw');
+      }
+    }
+  }
+
+  subscriberCount(projectId: string): number {
+    return this.subscribers.get(projectId)?.size ?? 0;
+  }
+}
+
+const g = globalThis as unknown as { __claudable_event_bus__?: EventBus };
+export const eventBus: EventBus = g.__claudable_event_bus__ ?? (g.__claudable_event_bus__ = new EventBus());

--- a/server/src/realtime/events.ts
+++ b/server/src/realtime/events.ts
@@ -1,0 +1,101 @@
+/**
+ * Normalized realtime event vocabulary streamed to the browser.
+ * Both the WebSocket and SSE transports carry these identical payloads.
+ */
+
+export type ToolAction =
+  | 'Read'
+  | 'Created'
+  | 'Edited'
+  | 'Deleted'
+  | 'Generated'
+  | 'Searched'
+  | 'Executed';
+
+export interface RealtimeEnvelope<T = unknown> {
+  /** event type discriminator */
+  type: string;
+  /** project this event belongs to */
+  projectId: string;
+  /** request that produced this event (when applicable) */
+  requestId?: string;
+  /** monotonically increasing per-connection sequence (added at send time) */
+  seq?: number;
+  /** ISO timestamp */
+  ts: string;
+  data: T;
+}
+
+/** Connection acknowledgement sent immediately on WS open. */
+export interface ConnectedEvent {
+  transport: 'websocket';
+  stage: 'handshake';
+}
+
+/** A persisted chat message (user/assistant/system/tool). */
+export interface MessageEvent {
+  id?: string;
+  role: 'user' | 'assistant' | 'system' | 'tool';
+  content: string;
+  metadata?: Record<string, unknown>;
+}
+
+/** Streaming token delta for an in-progress assistant message. */
+export interface AssistantDeltaEvent {
+  text: string;
+}
+
+/** A tool invocation (file edit, shell command, search, etc.). */
+export interface ToolEvent {
+  toolName: string;
+  action?: ToolAction;
+  filePath?: string;
+  command?: string;
+  summary?: string;
+  phase: 'start' | 'result';
+  output?: string;
+}
+
+/** Raw terminal / build output line. */
+export interface TerminalEvent {
+  stream: 'stdout' | 'stderr';
+  line: string;
+}
+
+/** Lifecycle / status change for the project or run. */
+export interface StatusEvent {
+  status: string;
+  detail?: string;
+}
+
+/** Run finished (success or failure). */
+export interface CompletionEvent {
+  ok: boolean;
+  durationMs?: number;
+  error?: string;
+}
+
+export type AnyRealtimeEvent =
+  | RealtimeEnvelope<ConnectedEvent>
+  | RealtimeEnvelope<MessageEvent>
+  | RealtimeEnvelope<AssistantDeltaEvent>
+  | RealtimeEnvelope<ToolEvent>
+  | RealtimeEnvelope<TerminalEvent>
+  | RealtimeEnvelope<StatusEvent>
+  | RealtimeEnvelope<CompletionEvent>;
+
+/** Helper to build a well-formed envelope. */
+export function makeEvent<T>(
+  type: string,
+  projectId: string,
+  data: T,
+  opts: { requestId?: string } = {},
+): RealtimeEnvelope<T> {
+  return {
+    type,
+    projectId,
+    requestId: opts.requestId,
+    ts: new Date().toISOString(),
+    data,
+  };
+}

--- a/server/src/realtime/ws-server.ts
+++ b/server/src/realtime/ws-server.ts
@@ -1,0 +1,124 @@
+/**
+ * WebSocket server attached to the shared HTTP server.
+ *
+ * Path: /api/ws/:projectId?access_token=<jwt>
+ * - Authenticates the Supabase JWT on upgrade.
+ * - Verifies the user owns the project.
+ * - Subscribes the socket to that project's event bus.
+ * - Heartbeats to drop dead connections.
+ */
+import { WebSocketServer, WebSocket } from 'ws';
+import type { IncomingMessage, Server as HttpServer } from 'http';
+import type { Socket } from 'net';
+import { eventBus } from './event-bus';
+import { makeEvent, type RealtimeEnvelope } from './events';
+import { authenticateToken } from '../middleware/auth';
+import { getProject } from '../services/projects';
+import { logger } from '../lib/logger';
+
+interface ManagedSocket extends WebSocket {
+  isAlive?: boolean;
+  seq?: number;
+}
+
+const WS_PATH_PREFIX = '/api/ws/';
+
+export function attachWebSocketServer(server: HttpServer): void {
+  const wss = new WebSocketServer({ noServer: true });
+
+  server.on('upgrade', (req: IncomingMessage, socket: Socket, head: Buffer) => {
+    let url: URL;
+    try {
+      url = new URL(req.url ?? '', 'http://localhost');
+    } catch {
+      socket.destroy();
+      return;
+    }
+
+    if (!url.pathname.startsWith(WS_PATH_PREFIX)) {
+      // Not ours — leave it for any other upgrade handler.
+      return;
+    }
+
+    const projectId = decodeURIComponent(url.pathname.slice(WS_PATH_PREFIX.length).split('/')[0] ?? '');
+    const token = url.searchParams.get('access_token');
+
+    void (async () => {
+      const user = await authenticateToken(token);
+      if (!user || !projectId) {
+        socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+        socket.destroy();
+        return;
+      }
+      const project = await getProject(projectId);
+      if (!project || project.user_id !== user.id) {
+        socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
+        socket.destroy();
+        return;
+      }
+
+      wss.handleUpgrade(req, socket, head, (ws) => {
+        wss.emit('connection', ws as ManagedSocket, projectId);
+      });
+    })().catch((err) => {
+      logger.error({ err }, 'WS upgrade failed');
+      try {
+        socket.destroy();
+      } catch {
+        /* ignore */
+      }
+    });
+  });
+
+  wss.on('connection', (ws: ManagedSocket, projectId: string) => {
+    ws.isAlive = true;
+    ws.seq = 0;
+    const log = logger.child({ projectId });
+    log.debug('WS connected');
+
+    const send = (event: RealtimeEnvelope) => {
+      if (ws.readyState !== WebSocket.OPEN) return;
+      ws.seq = (ws.seq ?? 0) + 1;
+      try {
+        ws.send(JSON.stringify({ ...event, seq: ws.seq }));
+      } catch (err) {
+        log.warn({ err }, 'WS send failed');
+      }
+    };
+
+    send(makeEvent('connected', projectId, { transport: 'websocket', stage: 'handshake' }));
+
+    const unsubscribe = eventBus.subscribe(projectId, send);
+
+    ws.on('pong', () => {
+      ws.isAlive = true;
+    });
+    ws.on('close', () => {
+      unsubscribe();
+      log.debug('WS closed');
+    });
+    ws.on('error', () => {
+      unsubscribe();
+    });
+  });
+
+  // Heartbeat: terminate sockets that stopped responding to pings.
+  const interval = setInterval(() => {
+    for (const client of wss.clients) {
+      const ws = client as ManagedSocket;
+      if (ws.isAlive === false) {
+        ws.terminate();
+        continue;
+      }
+      ws.isAlive = false;
+      try {
+        ws.ping();
+      } catch {
+        /* ignore */
+      }
+    }
+  }, 30_000);
+  interval.unref?.();
+
+  wss.on('close', () => clearInterval(interval));
+}

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -1,0 +1,7 @@
+import { Router } from 'express';
+
+export const healthRouter = Router();
+
+healthRouter.get('/healthz', (_req, res) => {
+  res.json({ ok: true, service: 'claudable-cloud-server', time: new Date().toISOString() });
+});

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -1,0 +1,212 @@
+/**
+ * Project management + execution + files + download.
+ * Every route is gated by requireAuth and getOwnedProject (ownership check).
+ */
+import { Router } from 'express';
+import { z } from 'zod';
+import { randomUUID } from 'node:crypto';
+import { asyncHandler, httpErrors } from '../lib/errors';
+import { requireAuth } from '../middleware/auth';
+import {
+  createProject,
+  deleteProject,
+  getOwnedProject,
+  listProjects,
+} from '../services/projects';
+import { appendMessage, listMessages } from '../services/chat';
+import { listTree, readFile } from '../services/files';
+import { archiveWorkspace, deleteArtifacts, getDownloadUrl } from '../services/storage';
+import { sessionManager } from '../workspace/session-manager';
+import { runClaude } from '../claude/runner';
+import { eventBus } from '../realtime/event-bus';
+import { makeEvent, type RealtimeEnvelope } from '../realtime/events';
+
+export const projectsRouter = Router();
+projectsRouter.use(requireAuth);
+
+const createSchema = z.object({
+  projectName: z.string().min(1).max(200),
+  description: z.string().max(2000).optional(),
+  initialPrompt: z.string().max(20000).optional(),
+  selectedModel: z.string().optional(),
+});
+
+// List the caller's projects.
+projectsRouter.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    const projects = await listProjects(req.user!.id);
+    res.json({ projects });
+  }),
+);
+
+// Create a project.
+projectsRouter.post(
+  '/',
+  asyncHandler(async (req, res) => {
+    const body = createSchema.parse(req.body);
+    const project = await createProject({ userId: req.user!.id, ...body });
+    res.status(201).json({ project });
+  }),
+);
+
+// Get one project.
+projectsRouter.get(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const project = await getOwnedProject(req.params.id, req.user!.id);
+    res.json({ project });
+  }),
+);
+
+// Delete a project (tears down container + artifacts + rows).
+projectsRouter.delete(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const project = await getOwnedProject(req.params.id, req.user!.id);
+    await sessionManager.destroyWorkspace(project.id).catch(() => {});
+    await deleteArtifacts(project.id).catch(() => {});
+    await deleteProject(project.id);
+    res.json({ ok: true });
+  }),
+);
+
+const actSchema = z.object({
+  instruction: z.string().min(1).max(20000),
+  isInitialPrompt: z.boolean().optional(),
+  selectedModel: z.string().optional(),
+  requestId: z.string().optional(),
+});
+
+// Execute a Claude Code turn. Returns immediately; output streams over WS/SSE.
+projectsRouter.post(
+  '/:id/act',
+  asyncHandler(async (req, res) => {
+    const project = await getOwnedProject(req.params.id, req.user!.id);
+    const body = actSchema.parse(req.body);
+    const requestId = body.requestId ?? randomUUID();
+
+    // Persist + broadcast the user message immediately.
+    const userMsg = await appendMessage({
+      projectId: project.id,
+      role: 'user',
+      message: body.instruction,
+      requestId,
+    });
+    eventBus.publish(
+      makeEvent('message', project.id, { id: userMsg.id, role: 'user', content: body.instruction }, { requestId }),
+    );
+
+    const isInitial = body.isInitialPrompt ?? !project.claude_session_id;
+
+    // Fire async — do not await the full run.
+    runClaude({
+      projectId: project.id,
+      prompt: body.instruction,
+      model: body.selectedModel ?? project.selected_model ?? undefined,
+      isInitial,
+      requestId,
+    }).catch(() => {
+      /* errors are reported via the event bus inside runClaude */
+    });
+
+    res.status(202).json({ ok: true, requestId, userMessageId: userMsg.id });
+  }),
+);
+
+// Conversation history.
+projectsRouter.get(
+  '/:id/messages',
+  asyncHandler(async (req, res) => {
+    const project = await getOwnedProject(req.params.id, req.user!.id);
+    const messages = await listMessages(project.id);
+    res.json({ messages });
+  }),
+);
+
+// SSE fallback stream (WebSocket is primary). Token via ?access_token=.
+projectsRouter.get(
+  '/:id/stream',
+  asyncHandler(async (req, res) => {
+    const project = await getOwnedProject(req.params.id, req.user!.id);
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    });
+    res.write(`data: ${JSON.stringify(makeEvent('connected', project.id, { transport: 'sse' }))}\n\n`);
+
+    const send = (event: RealtimeEnvelope) => {
+      res.write(`data: ${JSON.stringify(event)}\n\n`);
+    };
+    const unsubscribe = eventBus.subscribe(project.id, send);
+    const keepalive = setInterval(() => res.write(': ping\n\n'), 25_000);
+
+    req.on('close', () => {
+      clearInterval(keepalive);
+      unsubscribe();
+    });
+  }),
+);
+
+// File tree of the live workspace.
+projectsRouter.get(
+  '/:id/files',
+  asyncHandler(async (req, res) => {
+    const project = await getOwnedProject(req.params.id, req.user!.id);
+    if (!project.workspace_path) {
+      return res.json({ files: [] });
+    }
+    const files = await listTree(project.workspace_path);
+    res.json({ files });
+  }),
+);
+
+// File contents.
+projectsRouter.get(
+  '/:id/files/content',
+  asyncHandler(async (req, res) => {
+    const project = await getOwnedProject(req.params.id, req.user!.id);
+    const rel = req.query.path;
+    if (typeof rel !== 'string' || !rel) {
+      throw httpErrors.badRequest('Missing ?path');
+    }
+    if (!project.workspace_path) {
+      throw httpErrors.notFound('Workspace not provisioned');
+    }
+    const content = await readFile(project.workspace_path, rel);
+    res.json({ path: rel, content });
+  }),
+);
+
+// Stop the running workspace (archives first).
+projectsRouter.post(
+  '/:id/stop',
+  asyncHandler(async (req, res) => {
+    const project = await getOwnedProject(req.params.id, req.user!.id);
+    if (project.workspace_path) {
+      await archiveWorkspace(project.id, project.workspace_path).catch(() => {});
+    }
+    await sessionManager.stopWorkspace(project.id);
+    res.json({ ok: true });
+  }),
+);
+
+// Download the latest project archive as a signed URL.
+projectsRouter.get(
+  '/:id/download',
+  asyncHandler(async (req, res) => {
+    const project = await getOwnedProject(req.params.id, req.user!.id);
+    let objectPath = project.latest_artifact_path;
+    // If nothing archived yet but a workspace exists, snapshot on demand.
+    if (!objectPath && project.workspace_path) {
+      objectPath = await archiveWorkspace(project.id, project.workspace_path);
+    }
+    if (!objectPath) {
+      throw httpErrors.notFound('No artifact available to download');
+    }
+    const url = await getDownloadUrl(objectPath);
+    res.json({ url });
+  }),
+);

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -1,0 +1,50 @@
+/**
+ * User settings — BYOK Anthropic API key management.
+ * The raw key is write-only: clients can set, check status, or delete it, but
+ * can never read it back.
+ */
+import { Router } from 'express';
+import { z } from 'zod';
+import { asyncHandler } from '../lib/errors';
+import { requireAuth } from '../middleware/auth';
+import { maskKey } from '../lib/crypto';
+import {
+  deleteAnthropicKey,
+  hasAnthropicKey,
+  setAnthropicKey,
+} from '../services/user-settings';
+
+export const settingsRouter = Router();
+settingsRouter.use(requireAuth);
+
+const keySchema = z.object({
+  // Anthropic keys look like sk-ant-... ; keep the check loose but bounded.
+  apiKey: z.string().trim().min(20).max(400),
+});
+
+// Whether the caller has a key on file (never returns the key itself).
+settingsRouter.get(
+  '/anthropic-key',
+  asyncHandler(async (req, res) => {
+    res.json({ configured: await hasAnthropicKey(req.user!.id) });
+  }),
+);
+
+// Set / replace the caller's key.
+settingsRouter.put(
+  '/anthropic-key',
+  asyncHandler(async (req, res) => {
+    const { apiKey } = keySchema.parse(req.body);
+    await setAnthropicKey(req.user!.id, apiKey);
+    res.json({ ok: true, configured: true, masked: maskKey(apiKey) });
+  }),
+);
+
+// Remove the caller's key.
+settingsRouter.delete(
+  '/anthropic-key',
+  asyncHandler(async (req, res) => {
+    await deleteAnthropicKey(req.user!.id);
+    res.json({ ok: true, configured: false });
+  }),
+);

--- a/server/src/services/chat.ts
+++ b/server/src/services/chat.ts
@@ -1,0 +1,48 @@
+/**
+ * Chat history persistence (chat_sessions table).
+ */
+import { admin } from '../lib/supabase';
+import { httpErrors } from '../lib/errors';
+import type { ChatRole, ChatSessionRow } from '../types/db';
+
+const TABLE = 'chat_sessions';
+
+export async function appendMessage(input: {
+  projectId: string;
+  role: ChatRole;
+  message: string;
+  metadata?: Record<string, unknown>;
+  requestId?: string;
+}): Promise<ChatSessionRow> {
+  const { data, error } = await admin
+    .from(TABLE)
+    .insert({
+      project_id: input.projectId,
+      role: input.role,
+      message: input.message,
+      metadata: input.metadata ?? null,
+      request_id: input.requestId ?? null,
+    })
+    .select('*')
+    .single();
+  if (error || !data) {
+    throw httpErrors.internal(`Failed to append message: ${error?.message}`);
+  }
+  return data as ChatSessionRow;
+}
+
+export async function listMessages(
+  projectId: string,
+  opts: { limit?: number } = {},
+): Promise<ChatSessionRow[]> {
+  const { data, error } = await admin
+    .from(TABLE)
+    .select('*')
+    .eq('project_id', projectId)
+    .order('created_at', { ascending: true })
+    .limit(opts.limit ?? 1000);
+  if (error) {
+    throw httpErrors.internal(`Failed to list messages: ${error.message}`);
+  }
+  return (data ?? []) as ChatSessionRow[];
+}

--- a/server/src/services/files.ts
+++ b/server/src/services/files.ts
@@ -1,0 +1,75 @@
+/**
+ * Read-only access to a project's generated files on the host workspace path.
+ * Path traversal is blocked: resolved paths must stay within the workspace.
+ */
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { httpErrors } from '../lib/errors';
+
+const IGNORED = new Set(['node_modules', '.git', '.next', 'dist', '.turbo', '.cache']);
+
+export interface FileNode {
+  name: string;
+  path: string; // relative to workspace root
+  type: 'file' | 'dir';
+  size?: number;
+  children?: FileNode[];
+}
+
+function safeJoin(root: string, rel: string): string {
+  const resolved = path.resolve(root, rel);
+  if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+    throw httpErrors.badRequest('Path escapes workspace');
+  }
+  return resolved;
+}
+
+export async function listTree(workspacePath: string, maxDepth = 6): Promise<FileNode[]> {
+  async function walk(dir: string, rel: string, depth: number): Promise<FileNode[]> {
+    if (depth > maxDepth) return [];
+    let entries: import('node:fs').Dirent[];
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return [];
+    }
+    const nodes: FileNode[] = [];
+    for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+      if (IGNORED.has(entry.name)) continue;
+      const childRel = path.join(rel, entry.name);
+      const childAbs = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        nodes.push({
+          name: entry.name,
+          path: childRel,
+          type: 'dir',
+          children: await walk(childAbs, childRel, depth + 1),
+        });
+      } else if (entry.isFile()) {
+        let size: number | undefined;
+        try {
+          size = (await fs.stat(childAbs)).size;
+        } catch {
+          /* ignore */
+        }
+        nodes.push({ name: entry.name, path: childRel, type: 'file', size });
+      }
+    }
+    return nodes;
+  }
+  return walk(workspacePath, '', 0);
+}
+
+const MAX_FILE_BYTES = 1024 * 1024; // 1MB read cap
+
+export async function readFile(workspacePath: string, relPath: string): Promise<string> {
+  const abs = safeJoin(workspacePath, relPath);
+  const stat = await fs.stat(abs).catch(() => null);
+  if (!stat || !stat.isFile()) {
+    throw httpErrors.notFound('File not found');
+  }
+  if (stat.size > MAX_FILE_BYTES) {
+    throw httpErrors.badRequest('File too large to preview');
+  }
+  return fs.readFile(abs, 'utf8');
+}

--- a/server/src/services/projects.ts
+++ b/server/src/services/projects.ts
@@ -1,0 +1,106 @@
+/**
+ * Project data access. Uses the service-role client, so EVERY function that
+ * takes a userId enforces ownership explicitly — RLS does not apply here.
+ */
+import { admin } from '../lib/supabase';
+import { httpErrors } from '../lib/errors';
+import type { ProjectRow, ProjectStatus } from '../types/db';
+
+const TABLE = 'projects';
+
+export async function createProject(input: {
+  userId: string;
+  projectName: string;
+  description?: string;
+  initialPrompt?: string;
+  selectedModel?: string;
+}): Promise<ProjectRow> {
+  const { data, error } = await admin
+    .from(TABLE)
+    .insert({
+      user_id: input.userId,
+      project_name: input.projectName,
+      description: input.description ?? null,
+      initial_prompt: input.initialPrompt ?? null,
+      selected_model: input.selectedModel ?? null,
+      status: 'idle' satisfies ProjectStatus,
+    })
+    .select('*')
+    .single();
+  if (error || !data) {
+    throw httpErrors.internal(`Failed to create project: ${error?.message}`);
+  }
+  return data as ProjectRow;
+}
+
+export async function listProjects(userId: string): Promise<ProjectRow[]> {
+  const { data, error } = await admin
+    .from(TABLE)
+    .select('*')
+    .eq('user_id', userId)
+    .order('last_active_at', { ascending: false });
+  if (error) {
+    throw httpErrors.internal(`Failed to list projects: ${error.message}`);
+  }
+  return (data ?? []) as ProjectRow[];
+}
+
+/** Fetch a project, returning null if it does not exist. Does NOT check ownership. */
+export async function getProject(projectId: string): Promise<ProjectRow | null> {
+  const { data, error } = await admin.from(TABLE).select('*').eq('id', projectId).maybeSingle();
+  if (error) {
+    throw httpErrors.internal(`Failed to fetch project: ${error.message}`);
+  }
+  return (data as ProjectRow) ?? null;
+}
+
+/** Fetch a project and assert the given user owns it, else 404/403. */
+export async function getOwnedProject(projectId: string, userId: string): Promise<ProjectRow> {
+  const project = await getProject(projectId);
+  if (!project) {
+    throw httpErrors.notFound('Project not found');
+  }
+  if (project.user_id !== userId) {
+    // 404 (not 403) to avoid leaking existence of other users' projects.
+    throw httpErrors.notFound('Project not found');
+  }
+  return project;
+}
+
+export async function updateProject(
+  projectId: string,
+  patch: Partial<
+    Pick<
+      ProjectRow,
+      | 'status'
+      | 'workspace_path'
+      | 'container_id'
+      | 'claude_session_id'
+      | 'selected_model'
+      | 'latest_artifact_path'
+      | 'project_name'
+      | 'description'
+      | 'last_active_at'
+    >
+  >,
+): Promise<void> {
+  const { error } = await admin.from(TABLE).update(patch).eq('id', projectId);
+  if (error) {
+    throw httpErrors.internal(`Failed to update project: ${error.message}`);
+  }
+}
+
+export async function setProjectStatus(projectId: string, status: ProjectStatus): Promise<void> {
+  await updateProject(projectId, { status });
+}
+
+export async function touchProject(projectId: string): Promise<void> {
+  await updateProject(projectId, { last_active_at: new Date().toISOString() });
+}
+
+export async function deleteProject(projectId: string): Promise<void> {
+  const { error } = await admin.from(TABLE).delete().eq('id', projectId);
+  if (error) {
+    throw httpErrors.internal(`Failed to delete project: ${error.message}`);
+  }
+}

--- a/server/src/services/storage.ts
+++ b/server/src/services/storage.ts
@@ -1,0 +1,79 @@
+/**
+ * Project artifact storage. Archives a workspace directory into a tar.gz and
+ * uploads it to the Supabase Storage `project-artifacts` bucket; produces
+ * short-lived signed URLs for owner downloads.
+ */
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { createGzip } from 'node:zlib';
+import { pipeline } from 'node:stream/promises';
+import tar from 'tar-fs';
+import { env } from '../config/env';
+import { admin } from '../lib/supabase';
+import { logger } from '../lib/logger';
+import { httpErrors } from '../lib/errors';
+import { updateProject } from './projects';
+
+const BUCKET = env.SUPABASE_STORAGE_BUCKET;
+const IGNORE = ['node_modules', '.git', '.next', 'dist'];
+
+function artifactObjectPath(projectId: string): string {
+  return `${projectId}/workspace-${Date.now()}.tar.gz`;
+}
+
+/** Pack a workspace dir to a temp tar.gz and return its path + size. */
+async function packWorkspace(workspacePath: string): Promise<{ file: string; size: number }> {
+  const tmp = path.join(os.tmpdir(), `claudable-${Date.now()}.tar.gz`);
+  const out = fs.createWriteStream(tmp);
+  const packStream = tar.pack(workspacePath, {
+    ignore: (name) => IGNORE.some((seg) => name.split(path.sep).includes(seg)),
+  });
+  await pipeline(packStream, createGzip(), out);
+  const size = fs.statSync(tmp).size;
+  return { file: tmp, size };
+}
+
+/**
+ * Archive a project's workspace and upload it. Records latest_artifact_path on
+ * the project. Best-effort: never leaves a half-written "latest" pointer.
+ */
+export async function archiveWorkspace(projectId: string, workspacePath: string): Promise<string> {
+  const { file, size } = await packWorkspace(workspacePath);
+  try {
+    const objectPath = artifactObjectPath(projectId);
+    const body = fs.readFileSync(file);
+    const { error } = await admin.storage.from(BUCKET).upload(objectPath, body, {
+      contentType: 'application/gzip',
+      upsert: true,
+    });
+    if (error) {
+      throw httpErrors.internal(`Artifact upload failed: ${error.message}`);
+    }
+    // Only update the pointer after a successful upload.
+    await updateProject(projectId, { latest_artifact_path: objectPath });
+    logger.info({ projectId, objectPath, size }, 'Workspace archived');
+    return objectPath;
+  } finally {
+    fs.promises.unlink(file).catch(() => {});
+  }
+}
+
+/** Signed URL for the latest artifact, valid for `expiresInSec`. */
+export async function getDownloadUrl(objectPath: string, expiresInSec = 300): Promise<string> {
+  const { data, error } = await admin.storage.from(BUCKET).createSignedUrl(objectPath, expiresInSec);
+  if (error || !data?.signedUrl) {
+    throw httpErrors.internal(`Failed to create download URL: ${error?.message}`);
+  }
+  return data.signedUrl;
+}
+
+/** Remove all artifacts for a project (called on delete). */
+export async function deleteArtifacts(projectId: string): Promise<void> {
+  const { data, error } = await admin.storage.from(BUCKET).list(projectId);
+  if (error || !data) return;
+  const paths = data.map((o) => `${projectId}/${o.name}`);
+  if (paths.length > 0) {
+    await admin.storage.from(BUCKET).remove(paths).catch(() => {});
+  }
+}

--- a/server/src/services/user-settings.ts
+++ b/server/src/services/user-settings.ts
@@ -1,0 +1,57 @@
+/**
+ * Per-user settings, currently the BYOK Anthropic API key.
+ * The key is encrypted at the application layer before it ever touches the DB,
+ * and the plaintext is only ever returned internally to inject into a workspace
+ * — never sent back to the client.
+ */
+import { admin } from '../lib/supabase';
+import { httpErrors } from '../lib/errors';
+import { encryptSecret, decryptSecret } from '../lib/crypto';
+
+const TABLE = 'user_settings';
+
+export async function setAnthropicKey(userId: string, rawKey: string): Promise<void> {
+  const encrypted = encryptSecret(rawKey);
+  const { error } = await admin
+    .from(TABLE)
+    .upsert({ user_id: userId, anthropic_key_encrypted: encrypted }, { onConflict: 'user_id' });
+  if (error) {
+    throw httpErrors.internal(`Failed to save API key: ${error.message}`);
+  }
+}
+
+export async function hasAnthropicKey(userId: string): Promise<boolean> {
+  const { data, error } = await admin
+    .from(TABLE)
+    .select('anthropic_key_encrypted')
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (error) {
+    throw httpErrors.internal(`Failed to read settings: ${error.message}`);
+  }
+  return Boolean(data?.anthropic_key_encrypted);
+}
+
+/** Decrypted key for runtime injection. Returns null if unset or undecryptable. */
+export async function getAnthropicKey(userId: string): Promise<string | null> {
+  const { data, error } = await admin
+    .from(TABLE)
+    .select('anthropic_key_encrypted')
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (error || !data?.anthropic_key_encrypted) {
+    return null;
+  }
+  try {
+    return decryptSecret(data.anthropic_key_encrypted);
+  } catch {
+    return null;
+  }
+}
+
+export async function deleteAnthropicKey(userId: string): Promise<void> {
+  const { error } = await admin.from(TABLE).delete().eq('user_id', userId);
+  if (error) {
+    throw httpErrors.internal(`Failed to delete API key: ${error.message}`);
+  }
+}

--- a/server/src/types/db.ts
+++ b/server/src/types/db.ts
@@ -1,0 +1,60 @@
+/**
+ * Hand-maintained row types mirroring supabase/migrations.
+ * Keep in sync with the SQL; in CI you can regenerate with
+ * `supabase gen types typescript` and diff against this file.
+ */
+
+export type ProjectStatus =
+  | 'idle'
+  | 'provisioning'
+  | 'running'
+  | 'executing'
+  | 'stopped'
+  | 'error';
+
+export type ChatRole = 'user' | 'assistant' | 'system' | 'tool';
+
+export interface UserRow {
+  id: string;
+  email: string;
+  display_name: string | null;
+  created_at: string;
+}
+
+export interface ProjectRow {
+  id: string;
+  user_id: string;
+  project_name: string;
+  description: string | null;
+  status: ProjectStatus;
+  workspace_path: string | null;
+  container_id: string | null;
+  claude_session_id: string | null;
+  selected_model: string | null;
+  initial_prompt: string | null;
+  latest_artifact_path: string | null;
+  created_at: string;
+  updated_at: string;
+  last_active_at: string;
+}
+
+export interface ChatSessionRow {
+  id: string;
+  project_id: string;
+  role: ChatRole;
+  message: string;
+  metadata: Record<string, unknown> | null;
+  request_id: string | null;
+  created_at: string;
+}
+
+export interface ProjectFileRow {
+  id: string;
+  project_id: string;
+  filename: string;
+  language: string | null;
+  storage_path: string | null;
+  size_bytes: number | null;
+  created_at: string;
+  updated_at: string;
+}

--- a/server/src/workspace/docker-driver.ts
+++ b/server/src/workspace/docker-driver.ts
@@ -1,0 +1,184 @@
+/**
+ * DockerWorkspaceDriver — single-host implementation of WorkspaceDriver.
+ * Talks to the local Docker daemon via dockerode.
+ *
+ * Containers are labeled so the driver can find and reconcile them after a
+ * backend restart. Each project gets a deterministic container name so
+ * create() is idempotent.
+ */
+import Docker from 'dockerode';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { env } from '../config/env';
+import { logger } from '../lib/logger';
+import type { ExecOptions, ExecResult, WorkspaceDriver, WorkspaceHandle } from './driver';
+
+const LABEL_MANAGED = 'claudable.managed';
+const LABEL_PROJECT = 'claudable.projectId';
+
+function containerName(projectId: string): string {
+  return `claudable-ws-${projectId}`;
+}
+
+export class DockerWorkspaceDriver implements WorkspaceDriver {
+  private docker = new Docker();
+
+  async ensureImage(): Promise<void> {
+    try {
+      await this.docker.getImage(env.WORKSPACE_IMAGE).inspect();
+      return;
+    } catch {
+      logger.info({ image: env.WORKSPACE_IMAGE }, 'Workspace image not present locally; pulling');
+    }
+    await new Promise<void>((resolve, reject) => {
+      this.docker.pull(env.WORKSPACE_IMAGE, (err: unknown, stream: NodeJS.ReadableStream) => {
+        if (err) return reject(err);
+        this.docker.modem.followProgress(stream, (e: unknown) => (e ? reject(e) : resolve()));
+      });
+    });
+  }
+
+  private async hostWorkspaceDir(projectId: string): Promise<string> {
+    const dir = path.join(env.WORKSPACES_ROOT, projectId);
+    await fs.mkdir(dir, { recursive: true });
+    return dir;
+  }
+
+  async create(projectId: string): Promise<WorkspaceHandle> {
+    const name = containerName(projectId);
+
+    // Idempotent: reuse an existing container for this project if present.
+    const existing = this.docker.getContainer(name);
+    try {
+      const info = await existing.inspect();
+      if (!info.State.Running) {
+        await existing.start();
+      }
+      return {
+        containerId: info.Id,
+        workspacePath: await this.hostWorkspaceDir(projectId),
+      };
+    } catch {
+      // not found — fall through to create
+    }
+
+    const workspacePath = await this.hostWorkspaceDir(projectId);
+
+    const container = await this.docker.createContainer({
+      name,
+      Image: env.WORKSPACE_IMAGE,
+      Labels: { [LABEL_MANAGED]: 'true', [LABEL_PROJECT]: projectId },
+      Tty: false,
+      // No credential baked in — the per-user Anthropic key is injected per exec
+      // (see runner.ts -> WorkspaceDriver.exec opts.env).
+      Env: [],
+      WorkingDir: '/workspace',
+      HostConfig: {
+        Binds: [`${workspacePath}:/workspace`],
+        Memory: env.WORKSPACE_MEMORY_LIMIT_MB * 1024 * 1024,
+        NanoCpus: Math.round(env.WORKSPACE_CPU_LIMIT * 1e9),
+        // Security hardening: drop privileges, no new privileges.
+        CapDrop: ['ALL'],
+        SecurityOpt: ['no-new-privileges'],
+        PidsLimit: 512,
+      },
+    });
+
+    await container.start();
+    logger.info({ projectId, containerId: container.id }, 'Workspace container created');
+    return { containerId: container.id, workspacePath };
+  }
+
+  async isRunning(containerId: string): Promise<boolean> {
+    try {
+      const info = await this.docker.getContainer(containerId).inspect();
+      return info.State.Running === true;
+    } catch {
+      return false;
+    }
+  }
+
+  async start(containerId: string): Promise<void> {
+    await this.docker.getContainer(containerId).start();
+  }
+
+  async exec(containerId: string, opts: ExecOptions): Promise<ExecResult> {
+    const container = this.docker.getContainer(containerId);
+    const exec = await container.exec({
+      Cmd: opts.cmd,
+      WorkingDir: '/workspace',
+      Env: opts.env ? Object.entries(opts.env).map(([k, v]) => `${k}=${v}`) : undefined,
+      AttachStdout: true,
+      AttachStderr: true,
+      Tty: false,
+    });
+
+    const stream = await exec.start({ hijack: true, stdin: false });
+
+    // Demux Docker's multiplexed stream into stdout/stderr.
+    const stdoutSink = new WritableSink(opts.onStdout);
+    const stderrSink = new WritableSink(opts.onStderr);
+    this.docker.modem.demuxStream(stream, stdoutSink, stderrSink);
+
+    const onAbort = () => {
+      // Best-effort: killing the exec'd process isn't directly supported;
+      // stopping the container is the lever the session manager pulls.
+      stream.destroy();
+    };
+    opts.signal?.addEventListener('abort', onAbort, { once: true });
+
+    await new Promise<void>((resolve, reject) => {
+      stream.on('end', resolve);
+      stream.on('error', reject);
+    }).finally(() => {
+      opts.signal?.removeEventListener('abort', onAbort);
+    });
+
+    const info = await exec.inspect();
+    return { exitCode: info.ExitCode ?? 0 };
+  }
+
+  async stop(containerId: string): Promise<void> {
+    try {
+      await this.docker.getContainer(containerId).stop({ t: 5 });
+    } catch (err) {
+      logger.warn({ err, containerId }, 'Container stop failed (may already be stopped)');
+    }
+  }
+
+  async destroy(containerId: string): Promise<void> {
+    try {
+      await this.docker.getContainer(containerId).remove({ force: true });
+    } catch (err) {
+      logger.warn({ err, containerId }, 'Container remove failed');
+    }
+  }
+
+  async listManaged(): Promise<Array<{ containerId: string; projectId: string; running: boolean }>> {
+    const containers = await this.docker.listContainers({
+      all: true,
+      filters: { label: [`${LABEL_MANAGED}=true`] },
+    });
+    return containers.map((c) => ({
+      containerId: c.Id,
+      projectId: c.Labels?.[LABEL_PROJECT] ?? '',
+      running: c.State === 'running',
+    }));
+  }
+}
+
+/** Minimal Writable that forwards chunks to a callback (used for stream demux). */
+import { Writable } from 'node:stream';
+class WritableSink extends Writable {
+  constructor(private readonly onChunk?: (chunk: Buffer) => void) {
+    super();
+  }
+  _write(chunk: Buffer, _enc: BufferEncoding, cb: (e?: Error | null) => void): void {
+    try {
+      this.onChunk?.(chunk);
+      cb();
+    } catch (e) {
+      cb(e as Error);
+    }
+  }
+}

--- a/server/src/workspace/driver.ts
+++ b/server/src/workspace/driver.ts
@@ -1,0 +1,56 @@
+/**
+ * WorkspaceDriver — the ONLY abstraction the rest of the app uses to run
+ * workspace containers. The single-host Docker implementation lives in
+ * docker-driver.ts; swapping to ECS/Fargate/Fly later means writing a new
+ * driver and changing one line in session-manager.ts.
+ */
+
+export interface WorkspaceHandle {
+  /** opaque container/task id */
+  containerId: string;
+  /** host path bind-mounted to /workspace inside the container */
+  workspacePath: string;
+}
+
+export interface ExecResult {
+  exitCode: number;
+}
+
+export interface ExecOptions {
+  /** command + args, run inside /workspace */
+  cmd: string[];
+  /** extra env for this exec only (e.g. ANTHROPIC_API_KEY) */
+  env?: Record<string, string>;
+  /** called for each stdout chunk */
+  onStdout?: (chunk: Buffer) => void;
+  /** called for each stderr chunk */
+  onStderr?: (chunk: Buffer) => void;
+  /** abort signal to kill the exec (timeouts, cancellation) */
+  signal?: AbortSignal;
+}
+
+export interface WorkspaceDriver {
+  /** Pull/ensure the workspace image is available. */
+  ensureImage(): Promise<void>;
+
+  /** Create + start a container for a project. Idempotent per projectId. */
+  create(projectId: string): Promise<WorkspaceHandle>;
+
+  /** Whether a container is currently running. */
+  isRunning(containerId: string): Promise<boolean>;
+
+  /** Start an existing (stopped) container. */
+  start(containerId: string): Promise<void>;
+
+  /** Run a command inside the container, streaming output. */
+  exec(containerId: string, opts: ExecOptions): Promise<ExecResult>;
+
+  /** Gracefully stop a container (keeps it for restart). */
+  stop(containerId: string): Promise<void>;
+
+  /** Remove a container entirely. */
+  destroy(containerId: string): Promise<void>;
+
+  /** List container ids managed by this driver (for restart reconciliation). */
+  listManaged(): Promise<Array<{ containerId: string; projectId: string; running: boolean }>>;
+}

--- a/server/src/workspace/null-driver.ts
+++ b/server/src/workspace/null-driver.ts
@@ -1,0 +1,34 @@
+/**
+ * NullWorkspaceDriver — used when DISABLE_DOCKER=1 (local dev / CI without a
+ * Docker daemon). Lets the server boot and exercise routes without containers.
+ * exec() is a no-op that reports success.
+ */
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { env } from '../config/env';
+import { logger } from '../lib/logger';
+import type { ExecOptions, ExecResult, WorkspaceDriver, WorkspaceHandle } from './driver';
+
+export class NullWorkspaceDriver implements WorkspaceDriver {
+  async ensureImage(): Promise<void> {
+    logger.warn('DISABLE_DOCKER=1 — using NullWorkspaceDriver (no containers).');
+  }
+  async create(projectId: string): Promise<WorkspaceHandle> {
+    const workspacePath = path.join(env.WORKSPACES_ROOT, projectId);
+    await fs.mkdir(workspacePath, { recursive: true });
+    return { containerId: `null-${projectId}`, workspacePath };
+  }
+  async isRunning(): Promise<boolean> {
+    return true;
+  }
+  async start(): Promise<void> {}
+  async exec(_id: string, opts: ExecOptions): Promise<ExecResult> {
+    opts.onStdout?.(Buffer.from('[null-driver] docker disabled; no execution performed\n'));
+    return { exitCode: 0 };
+  }
+  async stop(): Promise<void> {}
+  async destroy(): Promise<void> {}
+  async listManaged(): Promise<Array<{ containerId: string; projectId: string; running: boolean }>> {
+    return [];
+  }
+}

--- a/server/src/workspace/process-driver.ts
+++ b/server/src/workspace/process-driver.ts
@@ -1,0 +1,122 @@
+/**
+ * LocalProcessWorkspaceDriver — runs Claude Code as a child process inside THIS
+ * container, with one directory per project under WORKSPACES_ROOT.
+ *
+ * Used on PaaS hosts (Railway, Render, Fly) that don't expose the host Docker
+ * daemon, so the sibling-container model isn't available. Tradeoff: projects
+ * share this process's container — no per-project kernel isolation. Acceptable
+ * for single-tenant / gated-demo deployments.
+ *
+ * Claude Code refuses `--dangerously-skip-permissions` when running as root, so
+ * when this server runs as root we drop each child to WORKSPACE_RUN_UID/GID.
+ */
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { env } from '../config/env';
+import { logger } from '../lib/logger';
+import type { ExecOptions, ExecResult, WorkspaceDriver, WorkspaceHandle } from './driver';
+
+const PREFIX = 'process-';
+
+function projectIdFromContainer(containerId: string): string {
+  return containerId.startsWith(PREFIX) ? containerId.slice(PREFIX.length) : containerId;
+}
+
+export class LocalProcessWorkspaceDriver implements WorkspaceDriver {
+  // setuid on a child only works when the parent is root.
+  private readonly canSetUid =
+    typeof process.getuid === 'function' && process.getuid() === 0;
+
+  async ensureImage(): Promise<void> {
+    if (!this.canSetUid && env.WORKSPACE_RUN_UID !== process.getuid?.()) {
+      logger.info('WORKSPACE_MODE=process: running children as current user (not root).');
+    }
+  }
+
+  private workspaceDir(projectId: string): string {
+    return path.join(env.WORKSPACES_ROOT, projectId);
+  }
+
+  /** Ensure the project dir exists and is owned by the run user (when root). */
+  private async ensureDir(projectId: string): Promise<string> {
+    const dir = this.workspaceDir(projectId);
+    await fs.mkdir(dir, { recursive: true });
+    if (this.canSetUid) {
+      await fs
+        .chown(dir, env.WORKSPACE_RUN_UID, env.WORKSPACE_RUN_GID)
+        .catch((err) => logger.warn({ err, dir }, 'workspace chown failed'));
+    }
+    return dir;
+  }
+
+  async create(projectId: string): Promise<WorkspaceHandle> {
+    const workspacePath = await this.ensureDir(projectId);
+    return { containerId: `${PREFIX}${projectId}`, workspacePath };
+  }
+
+  async isRunning(): Promise<boolean> {
+    // No container to keep alive; the directory is always "available".
+    return true;
+  }
+
+  async start(): Promise<void> {
+    /* no-op */
+  }
+
+  async exec(containerId: string, opts: ExecOptions): Promise<ExecResult> {
+    const projectId = projectIdFromContainer(containerId);
+    const cwd = await this.ensureDir(projectId);
+    const [command, ...args] = opts.cmd;
+
+    return new Promise<ExecResult>((resolve, reject) => {
+      const child = spawn(command, args, {
+        cwd,
+        env: {
+          ...process.env,
+          ...opts.env,
+          // Only override HOME when we're switching users; locally keep the real HOME.
+          ...(this.canSetUid ? { HOME: env.WORKSPACE_RUN_HOME } : {}),
+        },
+        ...(this.canSetUid ? { uid: env.WORKSPACE_RUN_UID, gid: env.WORKSPACE_RUN_GID } : {}),
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      const onAbort = () => child.kill('SIGTERM');
+      opts.signal?.addEventListener('abort', onAbort, { once: true });
+
+      child.stdout?.on('data', (c: Buffer) => opts.onStdout?.(c));
+      child.stderr?.on('data', (c: Buffer) => opts.onStderr?.(c));
+
+      child.on('error', (err) => {
+        opts.signal?.removeEventListener('abort', onAbort);
+        reject(err);
+      });
+      child.on('close', (code) => {
+        opts.signal?.removeEventListener('abort', onAbort);
+        resolve({ exitCode: code ?? 0 });
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    /* no persistent process to stop */
+  }
+
+  async destroy(containerId: string): Promise<void> {
+    const dir = this.workspaceDir(projectIdFromContainer(containerId));
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+
+  async listManaged(): Promise<Array<{ containerId: string; projectId: string; running: boolean }>> {
+    // Rebuild from on-disk workspace directories so restarts can adopt them.
+    try {
+      const entries = await fs.readdir(env.WORKSPACES_ROOT, { withFileTypes: true });
+      return entries
+        .filter((e) => e.isDirectory())
+        .map((e) => ({ containerId: `${PREFIX}${e.name}`, projectId: e.name, running: true }));
+    } catch {
+      return [];
+    }
+  }
+}

--- a/server/src/workspace/session-manager.ts
+++ b/server/src/workspace/session-manager.ts
@@ -1,0 +1,228 @@
+/**
+ * SessionManager — owns the lifecycle of every workspace container.
+ *
+ * Responsibilities:
+ *  - create / get-or-start / stop / destroy workspaces
+ *  - enforce a max-concurrent-running cap, queueing extra work
+ *  - track per-project state and last-activity for the idle reaper
+ *  - reconcile in-memory state with the driver after a backend restart
+ *
+ * Docker is reached only through the injected WorkspaceDriver, so this module
+ * is the single seam for swapping single-host Docker -> ECS/Fargate later.
+ */
+import { env } from '../config/env';
+import { logger } from '../lib/logger';
+import { httpErrors } from '../lib/errors';
+import { DockerWorkspaceDriver } from './docker-driver';
+import { LocalProcessWorkspaceDriver } from './process-driver';
+import { NullWorkspaceDriver } from './null-driver';
+import type { WorkspaceDriver, WorkspaceHandle } from './driver';
+import { getProject, updateProject, setProjectStatus } from '../services/projects';
+
+type WorkspaceState = 'idle' | 'starting' | 'running' | 'executing' | 'stopping';
+
+interface WorkspaceEntry {
+  projectId: string;
+  containerId: string;
+  workspacePath: string;
+  state: WorkspaceState;
+  lastActivity: number;
+}
+
+export class SessionManager {
+  private entries = new Map<string, WorkspaceEntry>();
+  private queue: Array<{ projectId: string; resolve: () => void; reject: (e: unknown) => void }> = [];
+  private reaper?: NodeJS.Timeout;
+
+  constructor(private readonly driver: WorkspaceDriver) {}
+
+  async init(): Promise<void> {
+    await this.driver.ensureImage();
+    await this.reconcile();
+    this.startReaper();
+  }
+
+  /** Number of containers currently running (not idle/stopped). */
+  private runningCount(): number {
+    let n = 0;
+    for (const e of this.entries.values()) {
+      if (e.state === 'running' || e.state === 'executing' || e.state === 'starting') n += 1;
+    }
+    return n;
+  }
+
+  /** Provision a brand-new workspace for a project. */
+  async createWorkspace(projectId: string): Promise<WorkspaceEntry> {
+    await this.acquireSlot(projectId);
+    try {
+      await setProjectStatus(projectId, 'provisioning');
+      const handle = await this.driver.create(projectId);
+      const entry = this.track(projectId, handle, 'running');
+      await updateProject(projectId, {
+        container_id: handle.containerId,
+        workspace_path: handle.workspacePath,
+        status: 'running',
+      });
+      return entry;
+    } catch (err) {
+      this.releaseSlot();
+      await setProjectStatus(projectId, 'error').catch(() => {});
+      throw err;
+    }
+  }
+
+  /** Get a running workspace for a project, starting/creating it as needed. */
+  async getOrStartWorkspace(projectId: string): Promise<WorkspaceEntry> {
+    const existing = this.entries.get(projectId);
+    if (existing && (await this.driver.isRunning(existing.containerId))) {
+      existing.lastActivity = Date.now();
+      return existing;
+    }
+
+    // Try to adopt a container recorded on the project row.
+    const project = await getProject(projectId);
+    if (project?.container_id && (await this.driver.isRunning(project.container_id))) {
+      const entry = this.track(
+        projectId,
+        { containerId: project.container_id, workspacePath: project.workspace_path ?? '' },
+        'running',
+      );
+      return entry;
+    }
+    if (project?.container_id) {
+      await this.acquireSlot(projectId);
+      try {
+        await this.driver.start(project.container_id);
+        const entry = this.track(
+          projectId,
+          { containerId: project.container_id, workspacePath: project.workspace_path ?? '' },
+          'running',
+        );
+        await setProjectStatus(projectId, 'running');
+        return entry;
+      } catch {
+        this.releaseSlot();
+        // container gone — fall through to recreate
+      }
+    }
+
+    return this.createWorkspace(projectId);
+  }
+
+  /** Mark a project as actively executing (reaper will skip it). */
+  markExecuting(projectId: string, executing: boolean): void {
+    const entry = this.entries.get(projectId);
+    if (!entry) return;
+    entry.state = executing ? 'executing' : 'running';
+    entry.lastActivity = Date.now();
+  }
+
+  async stopWorkspace(projectId: string): Promise<void> {
+    const entry = this.entries.get(projectId);
+    if (!entry) return;
+    entry.state = 'stopping';
+    await this.driver.stop(entry.containerId);
+    this.entries.delete(projectId);
+    this.releaseSlot();
+    await setProjectStatus(projectId, 'stopped').catch(() => {});
+  }
+
+  async destroyWorkspace(projectId: string): Promise<void> {
+    const project = await getProject(projectId);
+    const containerId = this.entries.get(projectId)?.containerId ?? project?.container_id ?? undefined;
+    if (containerId) {
+      await this.driver.destroy(containerId);
+    }
+    if (this.entries.delete(projectId)) {
+      this.releaseSlot();
+    }
+    await updateProject(projectId, { container_id: null, status: 'idle' }).catch(() => {});
+  }
+
+  getDriver(): WorkspaceDriver {
+    return this.driver;
+  }
+
+  getState(projectId: string): WorkspaceState | undefined {
+    return this.entries.get(projectId)?.state;
+  }
+
+  // --- internals ---
+
+  private track(projectId: string, handle: WorkspaceHandle, state: WorkspaceState): WorkspaceEntry {
+    const entry: WorkspaceEntry = {
+      projectId,
+      containerId: handle.containerId,
+      workspacePath: handle.workspacePath,
+      state,
+      lastActivity: Date.now(),
+    };
+    this.entries.set(projectId, entry);
+    return entry;
+  }
+
+  /** Wait for a concurrency slot; resolves immediately if under the cap. */
+  private acquireSlot(projectId: string): Promise<void> {
+    if (this.runningCount() < env.MAX_CONCURRENT_WORKSPACES) {
+      return Promise.resolve();
+    }
+    logger.info({ projectId, queued: this.queue.length + 1 }, 'Concurrency cap reached — queuing');
+    return new Promise<void>((resolve, reject) => {
+      this.queue.push({ projectId, resolve, reject });
+    });
+  }
+
+  private releaseSlot(): void {
+    const next = this.queue.shift();
+    if (next) next.resolve();
+  }
+
+  private startReaper(): void {
+    this.reaper = setInterval(() => {
+      const now = Date.now();
+      for (const entry of [...this.entries.values()]) {
+        if (entry.state === 'executing' || entry.state === 'stopping') continue;
+        if (now - entry.lastActivity > env.WORKSPACE_IDLE_TTL_MS) {
+          logger.info({ projectId: entry.projectId }, 'Reaping idle workspace');
+          // archive-then-stop is handled by the storage layer hook in stopWorkspace's caller;
+          // here we stop directly. (See storage.ts archiveWorkspace for persistence.)
+          this.stopWorkspace(entry.projectId).catch((err) =>
+            logger.warn({ err, projectId: entry.projectId }, 'Reaper stop failed'),
+          );
+        }
+      }
+    }, env.WORKSPACE_REAPER_INTERVAL_MS);
+    this.reaper.unref?.();
+  }
+
+  /** After a restart, rebuild in-memory entries from containers the driver still has. */
+  private async reconcile(): Promise<void> {
+    try {
+      const managed = await this.driver.listManaged();
+      for (const m of managed) {
+        if (!m.projectId) continue;
+        if (m.running) {
+          this.track(m.projectId, { containerId: m.containerId, workspacePath: '' }, 'running');
+        }
+      }
+      logger.info({ adopted: this.entries.size }, 'Reconciled workspace state after start');
+    } catch (err) {
+      logger.warn({ err }, 'Workspace reconciliation failed (continuing)');
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.reaper) clearInterval(this.reaper);
+  }
+}
+
+function selectDriver(): WorkspaceDriver {
+  if (env.DISABLE_DOCKER) return new NullWorkspaceDriver();
+  if (env.WORKSPACE_MODE === 'process') return new LocalProcessWorkspaceDriver();
+  return new DockerWorkspaceDriver();
+}
+
+// Singleton across imports / hot-reload.
+const g = globalThis as unknown as { __claudable_session_mgr__?: SessionManager };
+export const sessionManager: SessionManager =
+  g.__claudable_session_mgr__ ?? (g.__claudable_session_mgr__ = new SessionManager(selectDriver()));

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/supabase/migrations/0001_init.sql
+++ b/supabase/migrations/0001_init.sql
@@ -1,0 +1,164 @@
+-- Claudable Cloud — initial schema
+-- Multi-tenant: every row is owned by a user (directly or via its project).
+-- Row-Level Security is enabled on every table; policies restrict access to
+-- the authenticated owner. The backend uses the service-role key which
+-- bypasses RLS, so it must enforce ownership in application code as well.
+
+-- ============================================================
+-- Enums
+-- ============================================================
+do $$ begin
+  create type project_status as enum ('idle', 'provisioning', 'running', 'executing', 'stopped', 'error');
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create type chat_role as enum ('user', 'assistant', 'system', 'tool');
+exception when duplicate_object then null; end $$;
+
+-- ============================================================
+-- users  (profile mirror of auth.users)
+-- ============================================================
+create table if not exists public.users (
+  id uuid primary key references auth.users (id) on delete cascade,
+  email text not null,
+  display_name text,
+  created_at timestamptz not null default now()
+);
+
+-- Auto-create a profile row when a new auth user signs up.
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer set search_path = public
+as $$
+begin
+  insert into public.users (id, email)
+  values (new.id, new.email)
+  on conflict (id) do nothing;
+  return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute function public.handle_new_user();
+
+-- ============================================================
+-- projects
+-- ============================================================
+create table if not exists public.projects (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users (id) on delete cascade,
+  project_name text not null,
+  description text,
+  status project_status not null default 'idle',
+  -- host path of the bind-mounted workspace
+  workspace_path text,
+  -- docker container id for the active workspace (nullable when stopped)
+  container_id text,
+  -- Claude Code session id for multi-turn resumption
+  claude_session_id text,
+  selected_model text,
+  initial_prompt text,
+  -- storage path of the latest artifact archive
+  latest_artifact_path text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  last_active_at timestamptz not null default now()
+);
+create index if not exists projects_user_id_idx on public.projects (user_id);
+create index if not exists projects_status_idx on public.projects (status);
+
+-- ============================================================
+-- chat_sessions  (one row per message in a project's conversation)
+-- ============================================================
+create table if not exists public.chat_sessions (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects (id) on delete cascade,
+  role chat_role not null,
+  message text not null,
+  -- normalized event metadata: tool name, action, file path, summary, etc.
+  metadata jsonb,
+  -- ties assistant/tool messages back to the originating user request
+  request_id text,
+  created_at timestamptz not null default now()
+);
+create index if not exists chat_sessions_project_id_idx on public.chat_sessions (project_id);
+create index if not exists chat_sessions_created_at_idx on public.chat_sessions (created_at);
+create index if not exists chat_sessions_request_id_idx on public.chat_sessions (request_id);
+
+-- ============================================================
+-- project_files  (manifest of generated files, contents live in workspace/storage)
+-- ============================================================
+create table if not exists public.project_files (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects (id) on delete cascade,
+  filename text not null,
+  language text,
+  -- storage path inside the artifacts bucket, when persisted
+  storage_path text,
+  size_bytes bigint,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (project_id, filename)
+);
+create index if not exists project_files_project_id_idx on public.project_files (project_id);
+
+-- ============================================================
+-- updated_at maintenance
+-- ============================================================
+create or replace function public.touch_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists projects_touch on public.projects;
+create trigger projects_touch before update on public.projects
+  for each row execute function public.touch_updated_at();
+
+drop trigger if exists project_files_touch on public.project_files;
+create trigger project_files_touch before update on public.project_files
+  for each row execute function public.touch_updated_at();
+
+-- ============================================================
+-- Row-Level Security
+-- ============================================================
+alter table public.users enable row level security;
+alter table public.projects enable row level security;
+alter table public.chat_sessions enable row level security;
+alter table public.project_files enable row level security;
+
+-- users: a user can see and update only their own profile row.
+drop policy if exists users_select_own on public.users;
+create policy users_select_own on public.users
+  for select using (auth.uid() = id);
+drop policy if exists users_update_own on public.users;
+create policy users_update_own on public.users
+  for update using (auth.uid() = id);
+
+-- projects: full CRUD limited to the owner.
+drop policy if exists projects_owner_all on public.projects;
+create policy projects_owner_all on public.projects
+  for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+-- chat_sessions: access only if the parent project belongs to the user.
+drop policy if exists chat_sessions_owner_all on public.chat_sessions;
+create policy chat_sessions_owner_all on public.chat_sessions
+  for all using (
+    exists (select 1 from public.projects p where p.id = project_id and p.user_id = auth.uid())
+  ) with check (
+    exists (select 1 from public.projects p where p.id = project_id and p.user_id = auth.uid())
+  );
+
+-- project_files: same project-ownership gate.
+drop policy if exists project_files_owner_all on public.project_files;
+create policy project_files_owner_all on public.project_files
+  for all using (
+    exists (select 1 from public.projects p where p.id = project_id and p.user_id = auth.uid())
+  ) with check (
+    exists (select 1 from public.projects p where p.id = project_id and p.user_id = auth.uid())
+  );

--- a/supabase/migrations/0002_storage.sql
+++ b/supabase/migrations/0002_storage.sql
@@ -1,0 +1,32 @@
+-- Claudable Cloud — private storage bucket for generated project archives.
+-- Access is brokered by the backend via signed URLs; direct client access is
+-- still restricted to the owner so a leaked path cannot be downloaded by others.
+
+insert into storage.buckets (id, name, public)
+values ('project-artifacts', 'project-artifacts', false)
+on conflict (id) do nothing;
+
+-- Object paths are namespaced as: <project_id>/<filename>
+-- A user may read/write an object only if they own the project whose id is the
+-- first path segment.
+drop policy if exists artifacts_owner_select on storage.objects;
+create policy artifacts_owner_select on storage.objects
+  for select using (
+    bucket_id = 'project-artifacts'
+    and exists (
+      select 1 from public.projects p
+      where p.id::text = (storage.foldername(name))[1]
+        and p.user_id = auth.uid()
+    )
+  );
+
+drop policy if exists artifacts_owner_write on storage.objects;
+create policy artifacts_owner_write on storage.objects
+  for insert with check (
+    bucket_id = 'project-artifacts'
+    and exists (
+      select 1 from public.projects p
+      where p.id::text = (storage.foldername(name))[1]
+        and p.user_id = auth.uid()
+    )
+  );

--- a/supabase/migrations/0003_user_settings.sql
+++ b/supabase/migrations/0003_user_settings.sql
@@ -1,0 +1,20 @@
+-- Claudable Cloud — per-user settings (BYOK Anthropic API key).
+-- The key is stored AES-256-GCM encrypted by the backend; this column never
+-- holds plaintext. RLS still restricts the row to its owner as defense in depth.
+
+create table if not exists public.user_settings (
+  user_id uuid primary key references public.users (id) on delete cascade,
+  anthropic_key_encrypted text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.user_settings enable row level security;
+
+drop policy if exists user_settings_owner_all on public.user_settings;
+create policy user_settings_owner_all on public.user_settings
+  for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+drop trigger if exists user_settings_touch on public.user_settings;
+create trigger user_settings_touch before update on public.user_settings
+  for each row execute function public.touch_updated_at();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,6 +43,7 @@
   "exclude": [
     "node_modules",
     "data/projects",
-    "external_Claudable"
+    "external_Claudable",
+    "server"
   ]
 }

--- a/workspace-image/Dockerfile
+++ b/workspace-image/Dockerfile
@@ -1,0 +1,44 @@
+# Claudable Cloud — workspace container image.
+# A complete, isolated coding environment for ONE project. The orchestration
+# backend starts one container per project and execs headless Claude Code in it.
+#
+# ANTHROPIC_API_KEY is injected at `docker run` time (never baked in).
+FROM node:20-bookworm-slim
+
+# Pin tool versions for reproducibility.
+ARG CLAUDE_CODE_VERSION=latest
+ARG PNPM_VERSION=9.12.0
+
+# System build tools + git. Keep the layer lean.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+       git ca-certificates curl python3 build-essential tini \
+  && rm -rf /var/lib/apt/lists/*
+
+# Package managers + Claude Code (global).
+RUN corepack enable \
+  && corepack prepare pnpm@${PNPM_VERSION} --activate \
+  && npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
+  && npm cache clean --force
+
+# Non-root user. Claude Code must never run as root.
+RUN useradd --create-home --shell /bin/bash coder \
+  && mkdir -p /workspace \
+  && chown -R coder:coder /workspace
+
+USER coder
+WORKDIR /workspace
+
+# Claude Code reads ANTHROPIC_API_KEY from the environment at runtime.
+ENV NODE_ENV=development \
+    CI=1 \
+    NPM_CONFIG_FUND=false \
+    NPM_CONFIG_AUDIT=false
+
+# Expose the dev-server port range used by live preview (Phase B1).
+EXPOSE 3000-3010
+
+# tini reaps zombies; the long-sleep keeps the container alive so the backend
+# can `docker exec` multiple Claude Code turns into it.
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["sh", "-c", "echo 'workspace ready' && tail -f /dev/null"]


### PR DESCRIPTION
Adds a **cloud edition** of Claudable: Claude Code runs in per-user cloud workspaces and is driven entirely from the browser — no local install.

## Live URLs
- **Frontend:** https://claudable-web-production.up.railway.app
- **Backend API:** https://claudable-server-production.up.railway.app (`/healthz`)

## What's included
- `server/` — Node/TS orchestration backend: session manager + workspace lifecycle, headless Claude Code execution, WebSocket+SSE streaming, project/chat/files/storage APIs, Supabase auth.
- `app/cloud/` + `lib/cloud/` — Next.js cloud UI: login, dashboard, workspace (live streaming, file tree, download), BYOK key panel.
- `supabase/migrations/` — schema + RLS, storage bucket, `user_settings` (BYOK).
- **BYOK** — each user supplies their own Anthropic key (AES-256-GCM encrypted, injected per run).
- Railway Dockerfiles + `railway.json` for both services.

## Notes
- Two editions now coexist: original desktop app (unchanged) and this cloud edition (additive).
- Backend runs in `WORKSPACE_MODE=process` on Railway (no host Docker socket); a container-per-project Docker driver is included for a VM deployment.
- No secrets in the tree — keys live only in Railway env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)